### PR TITLE
[Fix] Operator: Sticky cookie corrected

### DIFF
--- a/internal/controller/reconcile-domains.go
+++ b/internal/controller/reconcile-domains.go
@@ -680,7 +680,7 @@ func (c *Controller) getUpdatedTenantDestinationRuleObject(ctx context.Context, 
 					ConsistentHash: &networkingv1beta1.LoadBalancerSettings_ConsistentHashLB{
 						HashKey: &networkingv1beta1.LoadBalancerSettings_ConsistentHashLB_HttpCookie{
 							HttpCookie: &networkingv1beta1.LoadBalancerSettings_ConsistentHashLB_HTTPCookie{
-								Name: HttpCookieName,
+								Name: RouterHttpCookieName,
 								Ttl:  durationpb.New(0 * time.Second),
 								Path: "/",
 							},

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -69,8 +69,8 @@ const (
 	ConsumerTenantType = "consumer"
 )
 
-// Use same name as default cookie from approuter used for session stickiness
-const HttpCookieName = "JSESSIONID"
+// Use a different name for sticky cookie than the one from approuter (JSESSIONID) used for session handling
+const RouterHttpCookieName = "CAPOP_ROUTER_STICKY"
 
 const (
 	EnvCAPOpAppVersion      = "CAPOP_APP_VERSION"

--- a/internal/controller/testdata/captenant/cat-04.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-04.expected.yaml
@@ -75,7 +75,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   annotations:
-    sme.sap.com/resource-hash: 5d065e2112f26ad9b5ace902461365ba9cbf539123dea326f060534bc30e22d1
+    sme.sap.com/resource-hash: 76ac6b80ce55711ae052011d8d29727030c897d4869ba6c403ac6842f08b93d6
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "0"
@@ -94,6 +94,6 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-          name: JSESSIONID
+          name: CAPOP_ROUTER_STICKY
           path: /
           ttl: 0s

--- a/internal/controller/testdata/captenant/cat-13.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-13.expected.yaml
@@ -80,7 +80,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   annotations:
-    sme.sap.com/resource-hash: ca930fa3ab9c0c67bf3d2d948cdacefd93505d6089f56ebcd7cc7cf06e66ad7d
+    sme.sap.com/resource-hash: 97ecccd1443b2219a85159a5fdb2f8444543746a5ae890114462e6666e556696
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   generation: 1
   labels:
@@ -100,6 +100,6 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-          name: JSESSIONID
+          name: CAPOP_ROUTER_STICKY
           path: /
           ttl: 0s

--- a/internal/controller/testdata/captenant/cat-15.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-15.expected.yaml
@@ -78,7 +78,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   annotations:
-    sme.sap.com/resource-hash: ca930fa3ab9c0c67bf3d2d948cdacefd93505d6089f56ebcd7cc7cf06e66ad7d
+    sme.sap.com/resource-hash: 97ecccd1443b2219a85159a5fdb2f8444543746a5ae890114462e6666e556696
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "3"
@@ -97,6 +97,6 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-          name: JSESSIONID
+          name: CAPOP_ROUTER_STICKY
           path: /
           ttl: 0s

--- a/internal/controller/testdata/captenant/cat-17.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-17.expected.yaml
@@ -78,7 +78,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   annotations:
-    sme.sap.com/resource-hash: ca930fa3ab9c0c67bf3d2d948cdacefd93505d6089f56ebcd7cc7cf06e66ad7d
+    sme.sap.com/resource-hash: 97ecccd1443b2219a85159a5fdb2f8444543746a5ae890114462e6666e556696
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "3"
@@ -97,7 +97,7 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-          name: JSESSIONID
+          name: CAPOP_ROUTER_STICKY
           path: /
           ttl: 0s
 ---

--- a/internal/controller/testdata/captenant/cat-17.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-17.initial.yaml
@@ -77,7 +77,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   annotations:
-    sme.sap.com/resource-hash: ca930fa3ab9c0c67bf3d2d948cdacefd93505d6089f56ebcd7cc7cf06e66ad7d
+    sme.sap.com/resource-hash: 97ecccd1443b2219a85159a5fdb2f8444543746a5ae890114462e6666e556696
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "3"
@@ -96,6 +96,6 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-          name: JSESSIONID
+          name: CAPOP_ROUTER_STICKY
           path: /
           ttl: 0s

--- a/internal/controller/testdata/captenant/provider-tenant-dr-v1.yaml
+++ b/internal/controller/testdata/captenant/provider-tenant-dr-v1.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1beta1
 kind: DestinationRule
 metadata:
   annotations:
-    sme.sap.com/resource-hash: 5d065e2112f26ad9b5ace902461365ba9cbf539123dea326f060534bc30e22d1
+    sme.sap.com/resource-hash: 76ac6b80ce55711ae052011d8d29727030c897d4869ba6c403ac6842f08b93d6
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   generation: 1
   labels:
@@ -22,6 +22,6 @@ spec:
     loadBalancer:
       consistentHash:
         httpCookie:
-          name: JSESSIONID
+          name: CAPOP_ROUTER_STICKY
           path: /
           ttl: 0s


### PR DESCRIPTION
In some cases using the same `JSESSIONID` cookie (as the one that approuter uses) does not seem to work!
Try to fix this by setting a different cookie `CAPOP_ROUTER_STICKY`.

Change-Id: I66b68a10ad66a9d3c3dbfd578096baf6d137b0e6