### PR TITLE
[Misc] Operator/server: Subscription Context saved

### DIFF
--- a/cmd/server/internal/handler_test.go
+++ b/cmd/server/internal/handler_test.go
@@ -264,7 +264,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request without CROs",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusNotAcceptable,
 			expectedResponse: Result{
 				Message: "the server could not find the requested resource (get capapplications.sme.sap.com)", //TODO
@@ -273,7 +273,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request with CROs with invalid app name",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"test-app","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `"}`,
+			body:               `{"subscriptionAppName":"test-app","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			expectedStatusCode: http.StatusNotAcceptable,
 			expectedResponse: Result{
@@ -283,7 +283,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request valid",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			expectedStatusCode: http.StatusAccepted,
 			expectedResponse: Result{
@@ -293,7 +293,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request with existing tenant",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			existingTenant:     true,
 			expectedStatusCode: http.StatusAccepted,
@@ -367,7 +367,7 @@ func Test_deprovisioning(t *testing.T) {
 			name:   "Deprovisioning Request w/o CROs",
 			method: http.MethodDelete,
 
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusNotAcceptable,
 			expectedResponse: Result{
 				Message: "the server could not find the requested resource (get capapplications.sme.sap.com)", //TODO
@@ -377,7 +377,7 @@ func Test_deprovisioning(t *testing.T) {
 			name:               "Deprovisioning Request valid",
 			method:             http.MethodDelete,
 			createCROs:         true,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusAccepted,
 			expectedResponse: Result{
 				Message: ResourceDeleted,
@@ -388,7 +388,7 @@ func Test_deprovisioning(t *testing.T) {
 			method:             http.MethodDelete,
 			createCROs:         true,
 			existingTenant:     true,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusAccepted,
 			expectedResponse: Result{
 				Message: ResourceDeleted,

--- a/internal/controller/testdata/captenantoperation/ctop-01.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-01.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"

--- a/internal/controller/testdata/captenantoperation/ctop-02.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-02.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"

--- a/internal/controller/testdata/captenantoperation/ctop-03.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-03.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"

--- a/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"

--- a/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"
@@ -92,6 +93,11 @@ spec:
               value: provisioning
             - name: CAPOP_TENANT_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_SUBSCRIPTION_PAYLOAD
+              valueFrom:
+                secretKeyRef:
+                  name: test-cap-01-gen
+                  key: subscriptionContext
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
@@ -101,6 +107,8 @@ spec:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
             - subscribe
             - tenant-id-for-provider
+            - --body
+            - $(CAPOP_SUBSCRIPTION_PAYLOAD)
           image: docker.image.repo/srv/server:latest
           imagePullPolicy: Always
           name: mtx

--- a/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"
@@ -92,6 +93,11 @@ spec:
               value: provisioning
             - name: CAPOP_TENANT_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_SUBSCRIPTION_PAYLOAD
+              valueFrom:
+                secretKeyRef:
+                  name: test-cap-01-gen
+                  key: subscriptionContext
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
@@ -101,6 +107,8 @@ spec:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
             - subscribe
             - tenant-id-for-provider
+            - --body
+            - $(CAPOP_SUBSCRIPTION_PAYLOAD)
           resources:
             limits:
               cpu: 200m

--- a/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"
@@ -92,6 +93,11 @@ spec:
               value: provisioning
             - name: CAPOP_TENANT_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_SUBSCRIPTION_PAYLOAD
+              valueFrom:
+                secretKeyRef:
+                  name: test-cap-01-gen
+                  key: subscriptionContext
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
@@ -101,6 +107,8 @@ spec:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
             - subscribe
             - tenant-id-for-provider
+            - --body
+            - $(CAPOP_SUBSCRIPTION_PAYLOAD)
           resources:
             limits:
               cpu: 200m

--- a/internal/controller/testdata/captenantoperation/ctop-24.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-24.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"
@@ -96,6 +97,11 @@ spec:
               value: provisioning
             - name: CAPOP_TENANT_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_SUBSCRIPTION_PAYLOAD
+              valueFrom:
+                secretKeyRef:
+                  name: test-cap-01-gen
+                  key: subscriptionContext
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen

--- a/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"
@@ -92,6 +93,11 @@ spec:
               value: provisioning
             - name: CAPOP_TENANT_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_SUBSCRIPTION_PAYLOAD
+              valueFrom:
+                secretKeyRef:
+                  name: test-cap-01-gen
+                  key: subscriptionContext
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
@@ -101,6 +107,8 @@ spec:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
             - subscribe
             - tenant-id-for-provider
+            - --body
+            - $(CAPOP_SUBSCRIPTION_PAYLOAD)
           resources:
             limits:
               cpu: 200m

--- a/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
@@ -8,6 +8,7 @@ metadata:
     - sme.sap.com/captenantoperation
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "0"
@@ -92,6 +93,11 @@ spec:
               value: provisioning
             - name: CAPOP_TENANT_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_SUBSCRIPTION_PAYLOAD
+              valueFrom:
+                secretKeyRef:
+                  name: test-cap-01-gen
+                  key: subscriptionContext
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
@@ -104,6 +110,8 @@ spec:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
             - subscribe
             - tenant-id-for-provider
+            - --body
+            - $(CAPOP_SUBSCRIPTION_PAYLOAD)
           resources:
             limits:
               cpu: 200m

--- a/internal/controller/testdata/common/captenant-provider-ready.yaml
+++ b/internal/controller/testdata/common/captenant-provider-ready.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-context-secret: test-cap-01-gen
   labels:
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/btp-tenant-id: tenant-id-for-provider


### PR DESCRIPTION
Save subscription payload as a context in a secret. This enables the operator to access the subscription payload during tenant provisioning and pass it along to mtxs (that now supports this).