### PR TITLE
Update sonar-project.properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,6 +12,8 @@ sonar.exclusions=**/temp.go,**/*_test.go,**/*.yaml
 sonar.tests=.
 sonar.test.inclusions=**/*_test.go
 
+sonar.coverage.exclusions=**/main.go,**/server.go
+
 sonar.go.coverage.reportPaths=coverage.out
 
 # Encoding of the source code. Default is default system encoding


### PR DESCRIPTION
Exclude main.go and server.go from test coverage during sonar scan executions.