### PR TITLE
[Misc] Operator: Tenant version upgrade amended

### DIFF
--- a/internal/controller/reconcile-capapplication.go
+++ b/internal/controller/reconcile-capapplication.go
@@ -158,6 +158,10 @@ func (c *Controller) checkNewCAPApplicationVersion(ctx context.Context, ca *v1al
 			// Skip non relevant tenants
 			continue
 		}
+		if tenant.Status.State == v1alpha1.CAPTenantStateProvisioning || tenant.Status.State == v1alpha1.CAPTenantStateUpgrading || tenant.Status.State == v1alpha1.CAPTenantStateDeleting {
+			// Skip tenants that are not ready or not in processing or not in error
+			continue
+		}
 		// Assume we may have to update the tenant and prepare a copy
 		cat := tenant.DeepCopy()
 

--- a/internal/controller/reconcile-capapplication_test.go
+++ b/internal/controller/reconcile-capapplication_test.go
@@ -1128,3 +1128,24 @@ func TestAdditionalConditionsWithTenantDeletingUpgradeStrategyNever(t *testing.T
 		},
 	)
 }
+
+func TestController_handleCAPApplicationConsistent_versionUpgrade(t *testing.T) {
+	reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplication, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-cap-01"}},
+		TestData{
+			description: "Consistent state with a CAV upgrade; one tenant already in upgrading state",
+			initialResources: []string{
+				"testdata/capapplication/ca-31.initial.yaml",
+				"testdata/capapplication/cav-name-modified-ready.yaml",
+				"testdata/capapplication/cat-provider-no-finalizers-ready.yaml",
+				"testdata/capapplication/cat-consumer-upgrading.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/capapplication/gateway.yaml",
+				"testdata/capapplication/istio-ingress-with-cert.yaml",
+				"testdata/capapplication/ca-dns.yaml",
+			},
+			expectedResources: "testdata/capapplication/ca-31.expected.yaml",
+		},
+	)
+}

--- a/internal/controller/testdata/capapplication/cat-consumer-upgrading.yaml
+++ b/internal/controller/testdata/capapplication/cat-consumer-upgrading.yaml
@@ -1,0 +1,36 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPTenant
+metadata:
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/btp-tenant-id: tenant-id-for-consumer
+    sme.sap.com/owner-generation: "2"
+    sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
+    sme.sap.com/tenant-type: consumer
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+    sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/btp-tenant-id: "provider-tenant-id"
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+  name: test-cap-01-consumer
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-cap-01
+      uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+spec:
+  capApplicationInstance: test-cap-01
+  subDomain: my-consumer
+  tenantId: tenant-id-for-consumer
+  version: 5.6.7
+status:
+  state: Upgrading
+  currentCAPApplicationVersionInstance: test-cap-01-cav-v1
+  conditions:
+    - message: "waiting for CAPTenantOperation default.test-cap-01-consumer-ctop-gen of type upgrade to complete"
+      reason: UpgradeOperationCreated
+      status: "False"
+      type: Ready


### PR DESCRIPTION
Do not update the version on the tenant spec, as long as tenant is in: "Provisioning", "Upgrading" or "Deleting" state.
This enables us to use Spec.Version in logs during tenant operations and also helps avoid misinterpretation about what version the tenant is on.