### PR TITLE
[Misc] Operator: InitContainers env vars enhanced

### DIFF
--- a/internal/controller/reconcile-capapplicationversion.go
+++ b/internal/controller/reconcile-capapplicationversion.go
@@ -312,7 +312,9 @@ func newContentDeploymentJob(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPAppli
 							SecurityContext: workload.JobDefinition.SecurityContext,
 						},
 					},
-					InitContainers:            workload.JobDefinition.InitContainers,
+					InitContainers: *updateInitContainers(workload.JobDefinition.InitContainers, []corev1.EnvVar{
+						{Name: EnvCAPOpAppVersion, Value: cav.Spec.Version},
+					}, vcapSecretName),
 					SecurityContext:           workload.JobDefinition.PodSecurityContext,
 					ServiceAccountName:        workload.JobDefinition.ServiceAccountName,
 					Volumes:                   workload.JobDefinition.Volumes,
@@ -618,8 +620,10 @@ func createDeployment(params *DeploymentParameters) *appsv1.Deployment {
 					Labels:      labels,
 				},
 				Spec: corev1.PodSpec{
-					ImagePullSecrets:          convertToLocalObjectReferences(params.CAV.Spec.RegistrySecrets),
-					InitContainers:            params.WorkloadDetails.DeploymentDefinition.InitContainers,
+					ImagePullSecrets: convertToLocalObjectReferences(params.CAV.Spec.RegistrySecrets),
+					InitContainers: *updateInitContainers(params.WorkloadDetails.DeploymentDefinition.InitContainers, []corev1.EnvVar{
+						{Name: EnvCAPOpAppVersion, Value: params.CAV.Spec.Version},
+					}, params.VCAPSecretName),
 					Containers:                getContainer(params),
 					ServiceAccountName:        params.WorkloadDetails.DeploymentDefinition.ServiceAccountName,
 					Volumes:                   params.WorkloadDetails.DeploymentDefinition.Volumes,

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -574,3 +574,17 @@ func copyMaps(originalMap map[string]string, additionalMap map[string]string) ma
 	}
 	return newMap
 }
+
+func updateInitContainers(initContainers []corev1.Container, additionalEnv []corev1.EnvVar, vcapSecretName string) *[]corev1.Container {
+	var updatedInitContainers []corev1.Container
+	if len(initContainers) > 0 {
+		updatedInitContainers = []corev1.Container{}
+		for _, container := range initContainers {
+			updatedContainer := container.DeepCopy()
+			updatedContainer.Env = append(updatedContainer.Env, additionalEnv...)
+			updatedContainer.EnvFrom = getEnvFrom(vcapSecretName)
+			updatedInitContainers = append(updatedInitContainers, *updatedContainer)
+		}
+	}
+	return &updatedInitContainers
+}

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-init.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-init.yaml
@@ -326,6 +326,12 @@ spec:
           env:
             - name: INIT_CONTAINER_ENV
               value: "init-container-env"
+            - name: CAPOP_APP_VERSION
+              value: "1.2.3"
+          envFrom:
+            - secretRef:
+                name: test-cap-01-cav-v1-app-router-gen
+                optional: true
           resources:
             limits:
               cpu: 100m
@@ -343,6 +349,12 @@ spec:
           env:
             - name: LOG_CONTAINER_ENV
               value: "log-container-env"
+            - name: CAPOP_APP_VERSION
+              value: "1.2.3"
+          envFrom:
+            - secretRef:
+                name: test-cap-01-cav-v1-app-router-gen
+                optional: true
           resources:
             limits:
               cpu: 100m

--- a/internal/controller/testdata/captenantoperation/ctop-init-custom.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-init-custom.expected.yaml
@@ -173,6 +173,18 @@ spec:
             env:
               - name: INIT_CONTAINER_ENV
                 value: "init-container-env"
+              - name: CAPOP_APP_VERSION
+                value: 8.9.10
+              - name: CAPOP_TENANT_ID
+                value: tenant-id-for-provider
+              - name: CAPOP_TENANT_OPERATION
+                value: upgrade
+              - name: CAPOP_TENANT_SUBDOMAIN
+                value: my-provider
+            envFrom:
+              - secretRef:
+                  name: test-cap-01-provider-abcd-custom-say-gen
+                  optional: true
             resources:
               limits:
                 cpu: 100m
@@ -190,6 +202,18 @@ spec:
             env:
               - name: LOG_CONTAINER_ENV
                 value: "log-container-env"
+              - name: CAPOP_APP_VERSION
+                value: 8.9.10
+              - name: CAPOP_TENANT_ID
+                value: tenant-id-for-provider
+              - name: CAPOP_TENANT_OPERATION
+                value: upgrade
+              - name: CAPOP_TENANT_SUBDOMAIN
+                value: my-provider
+            envFrom:
+              - secretRef:
+                  name: test-cap-01-provider-abcd-custom-say-gen
+                  optional: true
             resources:
               limits:
                 cpu: 100m

--- a/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
@@ -177,8 +177,20 @@ spec:
           - name: init-container
             image: docker.image.repo/init-container:latest
             env:
-              - name: INIT_CONTAINER_ENV
-                value: "init-container-env"
+            - name: INIT_CONTAINER_ENV
+              value: "init-container-env"
+            - name: CAPOP_APP_VERSION
+              value: 5.6.7
+            - name: CAPOP_TENANT_ID
+              value: tenant-id-for-provider
+            - name: CAPOP_TENANT_OPERATION
+              value: provisioning
+            - name: CAPOP_TENANT_SUBDOMAIN
+              value: my-provider
+            envFrom:
+              - secretRef:
+                  name: test-cap-01-provider-abcd-mtx-gen
+                  optional: true
             resources:
               limits:
                 cpu: 100m
@@ -196,6 +208,18 @@ spec:
             env:
               - name: LOG_CONTAINER_ENV
                 value: "log-container-env"
+              - name: CAPOP_APP_VERSION
+                value: 5.6.7
+              - name: CAPOP_TENANT_ID
+                value: tenant-id-for-provider
+              - name: CAPOP_TENANT_OPERATION
+                value: provisioning
+              - name: CAPOP_TENANT_SUBDOMAIN
+                value: my-provider
+            envFrom:
+              - secretRef:
+                  name: test-cap-01-provider-abcd-mtx-gen
+                  optional: true
             resources:
               limits:
                 cpu: 100m


### PR DESCRIPTION
Ensure similar autogenerated env vars (as present on the main container) also exists for initContainers.
Exceptions:
- Env added via configuration on main container are not copied over.
- Env needed for special handling (destination) is not copied over.