### PR TITLE
[FEAT] add container `args`

### DIFF
--- a/crds/sme.sap.com_capapplications.yaml
+++ b/crds/sme.sap.com_capapplications.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: capapplications.sme.sap.com
 spec:
   group: sme.sap.com

--- a/crds/sme.sap.com_capapplicationversions.yaml
+++ b/crds/sme.sap.com_capapplicationversions.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: capapplicationversions.sme.sap.com
 spec:
   group: sme.sap.com
@@ -540,6 +540,10 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                           type: object
+                        args:
+                          items:
+                            type: string
+                          type: array
                         command:
                           items:
                             type: string
@@ -1379,10 +1383,10 @@ spec:
                           properties:
                             deletionRules:
                               oneOf:
-                              - required:
-                                - metrics
-                              - required:
-                                - expression
+                                - required:
+                                    - metrics
+                                - required:
+                                    - expression
                               properties:
                                 expression:
                                   type: string
@@ -3044,6 +3048,10 @@ spec:
                                   x-kubernetes-list-type: atomic
                               type: object
                           type: object
+                        args:
+                          items:
+                            type: string
+                          type: array
                         backoffLimit:
                           format: int32
                           type: integer

--- a/crds/sme.sap.com_captenantoperations.yaml
+++ b/crds/sme.sap.com_captenantoperations.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: captenantoperations.sme.sap.com
 spec:
   group: sme.sap.com

--- a/crds/sme.sap.com_captenantoutputs.yaml
+++ b/crds/sme.sap.com_captenantoutputs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: captenantoutputs.sme.sap.com
 spec:
   group: sme.sap.com

--- a/crds/sme.sap.com_captenants.yaml
+++ b/crds/sme.sap.com_captenants.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.16.2
+    controller-gen.kubebuilder.io/version: v0.16.4
   name: captenants.sme.sap.com
 spec:
   group: sme.sap.com

--- a/internal/controller/reconcile-capapplicationversion.go
+++ b/internal/controller/reconcile-capapplicationversion.go
@@ -313,6 +313,7 @@ func newContentDeploymentJob(cav *v1alpha1.CAPApplicationVersion, workload *v1al
 							Image:           workload.JobDefinition.Image,
 							ImagePullPolicy: workload.JobDefinition.ImagePullPolicy,
 							Command:         workload.JobDefinition.Command,
+							Args:            workload.JobDefinition.Args,
 							Env: append([]corev1.EnvVar{
 								{Name: EnvCAPOpAppVersion, Value: cav.Spec.Version},
 							}, workload.JobDefinition.Env...),
@@ -754,6 +755,7 @@ func getContainer(params *DeploymentParameters) []corev1.Container {
 		Image:           params.WorkloadDetails.DeploymentDefinition.Image,
 		ImagePullPolicy: params.WorkloadDetails.DeploymentDefinition.ImagePullPolicy,
 		Command:         params.WorkloadDetails.DeploymentDefinition.Command,
+		Args:            params.WorkloadDetails.DeploymentDefinition.Args,
 		Env:             getEnv(params),
 		EnvFrom:         getEnvFrom(params.VCAPSecretName),
 		VolumeMounts:    params.WorkloadDetails.DeploymentDefinition.VolumeMounts,

--- a/internal/controller/reconcile-captenantoperation.go
+++ b/internal/controller/reconcile-captenantoperation.go
@@ -35,6 +35,7 @@ type tentantOperationWorkload struct {
 	image                     string
 	imagePullPolicy           corev1.PullPolicy
 	command                   []string
+	args                      []string
 	env                       []corev1.EnvVar
 	volumeMounts              []corev1.VolumeMount
 	volumes                   []corev1.Volume
@@ -484,7 +485,7 @@ func (c *Controller) createTenantOperationJob(ctx context.Context, ctop *v1alpha
 					RestartPolicy:             corev1.RestartPolicyNever,
 					ImagePullSecrets:          params.imagePullSecrets,
 					Containers:                getContainers(ctop, derivedWorkload, workload, params),
-					InitContainers:            *updateInitContainers(derivedWorkload.initContainers, getCTOPEnv(params, ctop), params.vcapSecretName),
+					InitContainers:            *updateInitContainers(derivedWorkload.initContainers, getCTOPEnv(params, ctop, v1alpha1.JobTenantOperation), params.vcapSecretName),
 					Volumes:                   derivedWorkload.volumes,
 					ServiceAccountName:        derivedWorkload.serviceAccountName,
 					SecurityContext:           derivedWorkload.podSecurityContext,
@@ -508,34 +509,25 @@ func getContainers(ctop *v1alpha1.CAPTenantOperation, derivedWorkload tentantOpe
 		Name:            workload.Name,
 		Image:           derivedWorkload.image,
 		ImagePullPolicy: derivedWorkload.imagePullPolicy,
-		Env:             append(getCTOPEnv(params, ctop), derivedWorkload.env...),
+		Env:             append(getCTOPEnv(params, ctop, v1alpha1.JobTenantOperation), derivedWorkload.env...),
 		EnvFrom:         getEnvFrom(params.vcapSecretName),
 		VolumeMounts:    derivedWorkload.volumeMounts,
 		Resources:       derivedWorkload.resources,
 		SecurityContext: derivedWorkload.securityContext,
 	}
 
-	var operation string
-
-	if ctop.Spec.Operation == v1alpha1.CAPTenantOperationTypeProvisioning {
-		operation = "subscribe"
-	} else if ctop.Spec.Operation == v1alpha1.CAPTenantOperationTypeUpgrade {
-		operation = "upgrade"
-	} else { // deprovisioning
-		operation = "unsubscribe"
-	}
-
 	appendCommand := false
 	if derivedWorkload.command != nil {
 		container.Command = derivedWorkload.command
+		container.Args = derivedWorkload.args
 	} else {
-		container.Command = []string{"node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx", operation, ctop.Spec.TenantId}
+		container.Command = []string{"node"}
+		container.Args = []string{"./node_modules/@sap/cds-mtxs/bin/cds-mtx", `$(` + EnvCAPOpTenantMtxsOperation + `)`, ctop.Spec.TenantId}
 		appendCommand = true
 	}
 	if ctop.Spec.Operation == v1alpha1.CAPTenantOperationTypeProvisioning {
-		container.Env = append(container.Env, corev1.EnvVar{Name: EnvCAPOpSubscriptionPayload, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: ctop.Annotations[AnnotationSubscriptionContextSecret]}, Key: SubscriptionContext}}})
 		if appendCommand {
-			container.Command = append(container.Command, "--body", `$(`+EnvCAPOpSubscriptionPayload+`)`)
+			container.Args = append(container.Args, "--body", `$(`+EnvCAPOpSubscriptionPayload+`)`)
 		}
 	}
 
@@ -570,6 +562,7 @@ func deriveWorkloadForTenantOperation(workload *v1alpha1.WorkloadDetails) tentan
 		result.image = workload.JobDefinition.Image
 		result.imagePullPolicy = workload.JobDefinition.ImagePullPolicy
 		result.command = workload.JobDefinition.Command
+		result.args = workload.JobDefinition.Args
 		result.env = workload.JobDefinition.Env
 		result.volumeMounts = workload.JobDefinition.VolumeMounts
 		result.volumes = workload.JobDefinition.Volumes
@@ -628,15 +621,16 @@ func (c *Controller) createCustomTenantOperationJob(ctx context.Context, ctop *v
 							Name:            workload.Name,
 							Image:           workload.JobDefinition.Image,
 							ImagePullPolicy: workload.JobDefinition.ImagePullPolicy,
-							Env:             append(getCTOPEnv(params, ctop), workload.JobDefinition.Env...),
+							Env:             append(getCTOPEnv(params, ctop, v1alpha1.JobCustomTenantOperation), workload.JobDefinition.Env...),
 							EnvFrom:         getEnvFrom(params.vcapSecretName),
 							VolumeMounts:    workload.JobDefinition.VolumeMounts,
 							Command:         workload.JobDefinition.Command,
+							Args:            workload.JobDefinition.Args,
 							Resources:       workload.JobDefinition.Resources,
 							SecurityContext: workload.JobDefinition.SecurityContext,
 						},
 					},
-					InitContainers: *updateInitContainers(workload.JobDefinition.InitContainers, getCTOPEnv(params, ctop), params.vcapSecretName),
+					InitContainers: *updateInitContainers(workload.JobDefinition.InitContainers, getCTOPEnv(params, ctop, v1alpha1.JobCustomTenantOperation), params.vcapSecretName),
 				},
 			},
 		},
@@ -677,8 +671,8 @@ func addCAPTenantOperationLabels(ctop *v1alpha1.CAPTenantOperation, cat *v1alpha
 	return updated
 }
 
-func getCTOPEnv(params *jobCreateParams, ctop *v1alpha1.CAPTenantOperation) []corev1.EnvVar {
-	return []corev1.EnvVar{
+func getCTOPEnv(params *jobCreateParams, ctop *v1alpha1.CAPTenantOperation, stepType v1alpha1.JobType) []corev1.EnvVar {
+	env := []corev1.EnvVar{
 		{Name: EnvCAPOpAppVersion, Value: params.version},
 		{Name: EnvCAPOpTenantId, Value: ctop.Spec.TenantId},
 		{Name: EnvCAPOpTenantOperation, Value: string(ctop.Spec.Operation)},
@@ -689,4 +683,19 @@ func getCTOPEnv(params *jobCreateParams, ctop *v1alpha1.CAPTenantOperation) []co
 		{Name: EnvCAPOpProviderTenantId, Value: params.providerTenantId},
 		{Name: EnvCAPOpProviderSubDomain, Value: params.providerSubdomain},
 	}
+
+	if stepType == v1alpha1.JobTenantOperation {
+		var operation string
+		if ctop.Spec.Operation == v1alpha1.CAPTenantOperationTypeProvisioning {
+			operation = "subscribe"
+			env = append(env, corev1.EnvVar{Name: EnvCAPOpSubscriptionPayload, ValueFrom: &corev1.EnvVarSource{SecretKeyRef: &corev1.SecretKeySelector{LocalObjectReference: corev1.LocalObjectReference{Name: ctop.Annotations[AnnotationSubscriptionContextSecret]}, Key: SubscriptionContext}}})
+		} else if ctop.Spec.Operation == v1alpha1.CAPTenantOperationTypeUpgrade {
+			operation = "upgrade"
+		} else { // deprovisioning
+			operation = "unsubscribe"
+		}
+		env = append(env, corev1.EnvVar{Name: EnvCAPOpTenantMtxsOperation, Value: operation})
+	}
+
+	return env
 }

--- a/internal/controller/reconcile-captenantoperation.go
+++ b/internal/controller/reconcile-captenantoperation.go
@@ -516,17 +516,13 @@ func getContainers(ctop *v1alpha1.CAPTenantOperation, derivedWorkload tentantOpe
 		SecurityContext: derivedWorkload.securityContext,
 	}
 
-	appendCommand := false
 	if derivedWorkload.command != nil {
 		container.Command = derivedWorkload.command
 		container.Args = derivedWorkload.args
 	} else {
-		container.Command = []string{"node"}
-		container.Args = []string{"./node_modules/@sap/cds-mtxs/bin/cds-mtx", `$(` + EnvCAPOpTenantMtxsOperation + `)`, ctop.Spec.TenantId}
-		appendCommand = true
-	}
-	if ctop.Spec.Operation == v1alpha1.CAPTenantOperationTypeProvisioning {
-		if appendCommand {
+		container.Command = []string{"node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx"} // Use entrypoint for mtxs as the command
+		container.Args = []string{`$(` + EnvCAPOpTenantMtxsOperation + `)`, ctop.Spec.TenantId}
+		if ctop.Spec.Operation == v1alpha1.CAPTenantOperationTypeProvisioning {
 			container.Args = append(container.Args, "--body", `$(`+EnvCAPOpSubscriptionPayload+`)`)
 		}
 	}

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -81,6 +81,7 @@ const (
 	EnvCAPOpTenantId            = "CAPOP_TENANT_ID"
 	EnvCAPOpTenantSubDomain     = "CAPOP_TENANT_SUBDOMAIN"
 	EnvCAPOpTenantOperation     = "CAPOP_TENANT_OPERATION"
+	EnvCAPOpTenantMtxsOperation = "CAPOP_TENANT_MTXS_OPERATION"
 	EnvCAPOpTenantType          = "CAPOP_TENANT_TYPE"
 	EnvCAPOpAppName             = "CAPOP_APP_NAME"
 	EnvCAPOpGlobalAccountId     = "CAPOP_GLOBAL_ACCOUNT_ID"

--- a/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
@@ -110,11 +110,14 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
-          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx", "subscribe", "tenant-id-for-provider", "--body", "$(CAPOP_SUBSCRIPTION_PAYLOAD)"]
+          command: ["node"]
+          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider", "--body", "$(CAPOP_SUBSCRIPTION_PAYLOAD)"]
           image: docker.image.repo/srv/server:latest
           name: mtx
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
@@ -116,8 +116,8 @@ spec:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
-          command: ["node"]
-          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider", "--body", "$(CAPOP_SUBSCRIPTION_PAYLOAD)"]
+          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx"]
+          args: ["$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider", "--body", "$(CAPOP_SUBSCRIPTION_PAYLOAD)"]
           image: docker.image.repo/srv/server:latest
           name: mtx
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-06.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-06.expected.yaml
@@ -114,8 +114,8 @@ spec:
             - secretRef:
                 name: test-cap-01-provider-abcd-cap-backend-gen
                 optional: true
-          command: ["node"]
-          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
+          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx"]
+          args: ["$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:v2
           name: cap-backend
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-06.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-06.expected.yaml
@@ -106,13 +106,16 @@ spec:
               value: tenant-id-for-provider
             - name: CAPOP_PROVIDER_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: upgrade
             - name: foo
               value: bar
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-cap-backend-gen
                 optional: true
-          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx", "upgrade", "tenant-id-for-provider"]
+          command: ["node"]
+          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:v2
           name: cap-backend
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-09.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-09.expected.yaml
@@ -110,13 +110,16 @@ spec:
               value: tenant-id-for-provider
             - name: CAPOP_PROVIDER_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: upgrade
             - name: flow
               value: glow
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-ten-op-gen
                 optional: true
-          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx", "upgrade", "tenant-id-for-provider"]
+          command: ["node"]
+          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:latest
           name: ten-op
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-09.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-09.expected.yaml
@@ -118,8 +118,8 @@ spec:
             - secretRef:
                 name: test-cap-01-provider-abcd-ten-op-gen
                 optional: true
-          command: ["node"]
-          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
+          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx"]
+          args: ["$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:latest
           name: ten-op
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-16.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-16.expected.yaml
@@ -104,11 +104,14 @@ spec:
               value: tenant-id-for-provider
             - name: CAPOP_PROVIDER_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: unsubscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
-          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx", "unsubscribe", "tenant-id-for-provider"]
+          command: ["node"]
+          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:latest
           name: mtx
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-16.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-16.expected.yaml
@@ -110,8 +110,8 @@ spec:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
-          command: ["node"]
-          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
+          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx"]
+          args: ["$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:latest
           name: mtx
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
@@ -110,14 +110,17 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - subscribe
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body
             - $(CAPOP_SUBSCRIPTION_PAYLOAD)

--- a/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
@@ -118,8 +118,8 @@ spec:
                 optional: true
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body

--- a/internal/controller/testdata/captenantoperation/ctop-19.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-19.expected.yaml
@@ -112,8 +112,8 @@ spec:
                 optional: true
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
           image: docker.image.repo/srv/server:latest

--- a/internal/controller/testdata/captenantoperation/ctop-19.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-19.expected.yaml
@@ -104,14 +104,17 @@ spec:
               value: tenant-id-for-provider
             - name: CAPOP_PROVIDER_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: unsubscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - unsubscribe
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
           image: docker.image.repo/srv/server:latest
           imagePullPolicy: Always

--- a/internal/controller/testdata/captenantoperation/ctop-20.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-20.expected.yaml
@@ -112,8 +112,8 @@ spec:
                 optional: true
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
           image: docker.image.repo/srv/server:latest

--- a/internal/controller/testdata/captenantoperation/ctop-20.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-20.expected.yaml
@@ -104,14 +104,17 @@ spec:
               value: tenant-id-for-provider
             - name: CAPOP_PROVIDER_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: upgrade
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - upgrade
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
           image: docker.image.repo/srv/server:latest
           imagePullPolicy: Always

--- a/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
@@ -110,14 +110,17 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - subscribe
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body
             - $(CAPOP_SUBSCRIPTION_PAYLOAD)

--- a/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
@@ -118,8 +118,8 @@ spec:
                 optional: true
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body

--- a/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
@@ -110,14 +110,17 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - subscribe
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body
             - $(CAPOP_SUBSCRIPTION_PAYLOAD)

--- a/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
@@ -118,8 +118,8 @@ spec:
                 optional: true
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body

--- a/internal/controller/testdata/captenantoperation/ctop-24.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-24.expected.yaml
@@ -114,6 +114,8 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen

--- a/internal/controller/testdata/captenantoperation/ctop-26.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-26.expected.yaml
@@ -116,8 +116,8 @@ spec:
             - secretRef:
                 name: test-cap-01-provider-abcd-ten-op-gen
                 optional: true
-          command: ["node"]
-          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
+          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx"]
+          args: ["$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:latest
           name: ten-op
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-26.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-26.expected.yaml
@@ -106,6 +106,8 @@ spec:
               value: tenant-id-for-provider
             - name: CAPOP_PROVIDER_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: upgrade
             - name: flow
               value: glow
             - name: IS_MTXS_ENABLED
@@ -114,7 +116,8 @@ spec:
             - secretRef:
                 name: test-cap-01-provider-abcd-ten-op-gen
                 optional: true
-          command: ["node", "./node_modules/@sap/cds-mtxs/bin/cds-mtx", "upgrade", "tenant-id-for-provider"]
+          command: ["node"]
+          args: ["./node_modules/@sap/cds-mtxs/bin/cds-mtx", "$(CAPOP_TENANT_MTXS_OPERATION)", "tenant-id-for-provider"]
           image: docker.image.repo/srv/server:latest
           name: ten-op
       imagePullSecrets:

--- a/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
@@ -121,8 +121,8 @@ spec:
               name: cache-vol
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body

--- a/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
@@ -110,6 +110,8 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
@@ -119,8 +121,9 @@ spec:
               name: cache-vol
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - subscribe
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body
             - $(CAPOP_SUBSCRIPTION_PAYLOAD)
@@ -207,6 +210,13 @@ spec:
               value: tenant-id-for-provider
             - name: CAPOP_PROVIDER_SUBDOMAIN
               value: my-provider
+            - name: CAPOP_SUBSCRIPTION_PAYLOAD
+              valueFrom:
+                secretKeyRef:
+                  name: test-cap-01-gen
+                  key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
             envFrom:
               - secretRef:
                   name: test-cap-01-provider-abcd-mtx-gen
@@ -246,6 +256,13 @@ spec:
                 value: tenant-id-for-provider
               - name: CAPOP_PROVIDER_SUBDOMAIN
                 value: my-provider
+              - name: CAPOP_SUBSCRIPTION_PAYLOAD
+                valueFrom:
+                  secretKeyRef:
+                    name: test-cap-01-gen
+                    key: subscriptionContext
+              - name: CAPOP_TENANT_MTXS_OPERATION
+                value: subscribe
             envFrom:
               - secretRef:
                   name: test-cap-01-provider-abcd-mtx-gen

--- a/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
@@ -110,14 +110,17 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
                 optional: true
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - subscribe
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body
             - $(CAPOP_SUBSCRIPTION_PAYLOAD)

--- a/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
@@ -118,8 +118,8 @@ spec:
                 optional: true
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body

--- a/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
@@ -121,8 +121,8 @@ spec:
               name: cache-vol
           command:
             - node
-          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
+          args:
             - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body

--- a/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
@@ -110,6 +110,8 @@ spec:
                 secretKeyRef:
                   name: test-cap-01-gen
                   key: subscriptionContext
+            - name: CAPOP_TENANT_MTXS_OPERATION
+              value: subscribe
           envFrom:
             - secretRef:
                 name: test-cap-01-provider-abcd-mtx-gen
@@ -119,8 +121,9 @@ spec:
               name: cache-vol
           command:
             - node
+          args:
             - ./node_modules/@sap/cds-mtxs/bin/cds-mtx
-            - subscribe
+            - $(CAPOP_TENANT_MTXS_OPERATION)
             - tenant-id-for-provider
             - --body
             - $(CAPOP_SUBSCRIPTION_PAYLOAD)

--- a/pkg/apis/sme.sap.com/v1alpha1/types.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/types.go
@@ -367,6 +367,8 @@ type CommonDetails struct {
 	ImagePullPolicy corev1.PullPolicy `json:"imagePullPolicy,omitempty"`
 	// Entrypoint array for the container
 	Command []string `json:"command,omitempty"`
+	// Arguments to the entrypoint
+	Args []string `json:"args,omitempty"`
 	// Environment Config for the Container
 	Env []corev1.EnvVar `json:"env,omitempty"`
 	// Volume Configuration for the Pod

--- a/pkg/apis/sme.sap.com/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/zz_generated.deepcopy.go
@@ -609,6 +609,11 @@ func (in *CommonDetails) DeepCopyInto(out *CommonDetails) {
 		*out = make([]string, len(*in))
 		copy(*out, *in)
 	}
+	if in.Args != nil {
+		in, out := &in.Args, &out.Args
+		*out = make([]string, len(*in))
+		copy(*out, *in)
+	}
 	if in.Env != nil {
 		in, out := &in.Env, &out.Env
 		*out = make([]v1.EnvVar, len(*in))

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/commondetails.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/commondetails.go
@@ -17,6 +17,7 @@ type CommonDetailsApplyConfiguration struct {
 	Image                     *string                       `json:"image,omitempty"`
 	ImagePullPolicy           *v1.PullPolicy                `json:"imagePullPolicy,omitempty"`
 	Command                   []string                      `json:"command,omitempty"`
+	Args                      []string                      `json:"args,omitempty"`
 	Env                       []v1.EnvVar                   `json:"env,omitempty"`
 	Volumes                   []v1.Volume                   `json:"volumes,omitempty"`
 	VolumeMounts              []v1.VolumeMount              `json:"volumeMounts,omitempty"`
@@ -61,6 +62,16 @@ func (b *CommonDetailsApplyConfiguration) WithImagePullPolicy(value v1.PullPolic
 func (b *CommonDetailsApplyConfiguration) WithCommand(values ...string) *CommonDetailsApplyConfiguration {
 	for i := range values {
 		b.Command = append(b.Command, values[i])
+	}
+	return b
+}
+
+// WithArgs adds the given value to the Args field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Args field.
+func (b *CommonDetailsApplyConfiguration) WithArgs(values ...string) *CommonDetailsApplyConfiguration {
+	for i := range values {
+		b.Args = append(b.Args, values[i])
 	}
 	return b
 }

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/deploymentdetails.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/deploymentdetails.go
@@ -56,6 +56,16 @@ func (b *DeploymentDetailsApplyConfiguration) WithCommand(values ...string) *Dep
 	return b
 }
 
+// WithArgs adds the given value to the Args field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Args field.
+func (b *DeploymentDetailsApplyConfiguration) WithArgs(values ...string) *DeploymentDetailsApplyConfiguration {
+	for i := range values {
+		b.Args = append(b.Args, values[i])
+	}
+	return b
+}
+
 // WithEnv adds the given value to the Env field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Env field.

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/jobdetails.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/jobdetails.go
@@ -53,6 +53,16 @@ func (b *JobDetailsApplyConfiguration) WithCommand(values ...string) *JobDetails
 	return b
 }
 
+// WithArgs adds the given value to the Args field in the declarative configuration
+// and returns the receiver, so that objects can be build by chaining "With" function invocations.
+// If called multiple times, values provided by each call will be appended to the Args field.
+func (b *JobDetailsApplyConfiguration) WithArgs(values ...string) *JobDetailsApplyConfiguration {
+	for i := range values {
+		b.Args = append(b.Args, values[i])
+	}
+	return b
+}
+
 // WithEnv adds the given value to the Env field in the declarative configuration
 // and returns the receiver, so that objects can be build by chaining "With" function invocations.
 // If called multiple times, values provided by each call will be appended to the Env field.


### PR DESCRIPTION
CHANGES:
- added `args` to containers (includes CRD changes)
- added an environment variable `CAPOP_TENANT_MTXS_OPERATION ` for tenant operations to supply the `mtxs` command. All tenant operation related environment variables, including subscription payload, are now available in the corresponding `initContainers`

Controller image for testing: `ghcr.io/pavan-sap/cap-operator/controller:0.11.0`