### PR TITLE
[Update] Operator: Networking - istio v1 APIs used

### DIFF
--- a/internal/controller/informers.go
+++ b/internal/controller/informers.go
@@ -137,12 +137,12 @@ func (c *Controller) registerJobListeners() {
 }
 
 func (c *Controller) registerVirtualServiceListeners() {
-	c.istioInformerFactory.Networking().V1beta1().VirtualServices().Informer().
+	c.istioInformerFactory.Networking().V1().VirtualServices().Informer().
 		AddEventHandler(c.getEventHandlerFuncsForResource(ResourceVirtualService))
 }
 
 func (c *Controller) registerDestinationRuleListeners() {
-	c.istioInformerFactory.Networking().V1beta1().DestinationRules().Informer().
+	c.istioInformerFactory.Networking().V1().DestinationRules().Informer().
 		AddEventHandler(c.getEventHandlerFuncsForResource(ResourceDestinationRule))
 }
 
@@ -152,7 +152,7 @@ func (c *Controller) registerSecretListeners() {
 }
 
 func (c *Controller) registerGatewayListeners() {
-	c.istioInformerFactory.Networking().V1beta1().Gateways().Informer().
+	c.istioInformerFactory.Networking().V1().Gateways().Informer().
 		AddEventHandler(c.getEventHandlerFuncsForResource(ResourceGateway))
 }
 

--- a/internal/controller/reconcile-captenant_test.go
+++ b/internal/controller/reconcile-captenant_test.go
@@ -145,11 +145,11 @@ func TestCAPTenantProvisioningCompletedDestinationRuleModificationFailure(t *tes
 				"testdata/captenant/cat-04.initial.yaml",
 			},
 			expectError:           true,
-			mockErrorForResources: []ResourceAction{{Verb: "create", Group: "networking.istio.io", Version: "v1beta1", Resource: "destinationrules", Namespace: "default", Name: "test-cap-01-provider"}},
+			mockErrorForResources: []ResourceAction{{Verb: "create", Group: "networking.istio.io", Version: "v1", Resource: "destinationrules", Namespace: "default", Name: "test-cap-01-provider"}},
 			backlogItems:          []string{"ERP4SMEPREPWORKAPPPLAT-2811"},
 		},
 	)
-	if err.Error() != "mocked api error (destinationrules.networking.istio.io/v1beta1)" {
+	if err.Error() != "mocked api error (destinationrules.networking.istio.io/v1)" {
 		t.Error("error message is different from expected")
 	}
 }

--- a/internal/controller/reconcile-domains_test.go
+++ b/internal/controller/reconcile-domains_test.go
@@ -13,7 +13,7 @@ import (
 	certManagerv1 "github.com/cert-manager/cert-manager/pkg/apis/certmanager/v1"
 	certv1alpha1 "github.com/gardener/cert-management/pkg/apis/cert/v1alpha1"
 	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
-	istionwv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	istionwv1 "istio.io/client-go/pkg/apis/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 )
@@ -202,8 +202,8 @@ func TestController_reconcileOperatorDomains(t *testing.T) {
 			}
 
 			if tt.updateCA {
-				var gw *istionwv1beta1.Gateway
-				listGWs, _ := c.istioClient.NetworkingV1beta1().Gateways(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.SelectorFromValidatedSet(map[string]string{LabelOwnerIdentifierHash: sha1Sum(CAPOperator, OperatorDomains)}).String()})
+				var gw *istionwv1.Gateway
+				listGWs, _ := c.istioClient.NetworkingV1().Gateways(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.SelectorFromValidatedSet(map[string]string{LabelOwnerIdentifierHash: sha1Sum(CAPOperator, OperatorDomains)}).String()})
 				if len(listGWs.Items) > 0 {
 					gw = listGWs.Items[0]
 					generateMetaObjName(gw)
@@ -238,9 +238,9 @@ func TestController_reconcileOperatorDomains(t *testing.T) {
 			}
 
 			if tt.cleanUpDomains {
-				var gw *istionwv1beta1.Gateway
+				var gw *istionwv1.Gateway
 				var ingressGW2 *ingressResources
-				listGWs, _ := c.istioClient.NetworkingV1beta1().Gateways(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.SelectorFromValidatedSet(map[string]string{LabelOwnerIdentifierHash: sha1Sum(CAPOperator, OperatorDomains)}).String()})
+				listGWs, _ := c.istioClient.NetworkingV1().Gateways(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.SelectorFromValidatedSet(map[string]string{LabelOwnerIdentifierHash: sha1Sum(CAPOperator, OperatorDomains)}).String()})
 				if len(listGWs.Items) > 0 {
 					gw = listGWs.Items[0]
 					generateMetaObjName(gw)
@@ -279,8 +279,8 @@ func TestController_reconcileOperatorDomains(t *testing.T) {
 				}
 			}
 
-			var gw *istionwv1beta1.Gateway
-			listGWs, _ := c.istioClient.NetworkingV1beta1().Gateways(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.SelectorFromValidatedSet(map[string]string{LabelOwnerIdentifierHash: sha1Sum(CAPOperator, OperatorDomains)}).String()})
+			var gw *istionwv1.Gateway
+			listGWs, _ := c.istioClient.NetworkingV1().Gateways(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{LabelSelector: labels.SelectorFromValidatedSet(map[string]string{LabelOwnerIdentifierHash: sha1Sum(CAPOperator, OperatorDomains)}).String()})
 			if len(listGWs.Items) > 0 {
 				gw = listGWs.Items[0]
 			}

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -30,7 +30,7 @@ import (
 	promopFake "github.com/prometheus-operator/prometheus-operator/pkg/client/versioned/fake"
 	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
 	"github.com/sap/cap-operator/pkg/client/clientset/versioned/fake"
-	istionwv1beta1 "istio.io/client-go/pkg/apis/networking/v1beta1"
+	istionwv1 "istio.io/client-go/pkg/apis/networking/v1"
 	istiofake "istio.io/client-go/pkg/clientset/versioned/fake"
 )
 
@@ -68,7 +68,7 @@ type testResources struct {
 	cats            []*v1alpha1.CAPTenant
 	ctops           []*v1alpha1.CAPTenantOperation
 	ingressGW       []*ingressResources
-	gateway         *istionwv1beta1.Gateway
+	gateway         *istionwv1.Gateway
 	gardenerCert    *certv1alpha1.Certificate
 	certManagerCert *certManagerv1.Certificate
 	dnsEntry        *dnsv1alpha1.DNSEntry
@@ -369,8 +369,8 @@ func getTestController(resources testResources) *Controller {
 	}
 
 	if resources.gateway != nil {
-		c.istioClient.NetworkingV1beta1().Gateways(resources.gateway.Namespace).Create(context.TODO(), resources.gateway, metav1.CreateOptions{})
-		c.istioInformerFactory.Networking().V1beta1().Gateways().Informer().GetIndexer().Add(resources.gateway)
+		c.istioClient.NetworkingV1().Gateways(resources.gateway.Namespace).Create(context.TODO(), resources.gateway, metav1.CreateOptions{})
+		c.istioInformerFactory.Networking().V1().Gateways().Informer().GetIndexer().Add(resources.gateway)
 	}
 
 	if resources.gardenerCert != nil {

--- a/internal/controller/testdata/capapplication/gateway.yaml
+++ b/internal/controller/testdata/capapplication/gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   generation: 1

--- a/internal/controller/testdata/captenant/cat-04.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-04.expected.yaml
@@ -36,7 +36,7 @@ status:
   state: Ready
   currentCAPApplicationVersionInstance: test-cap-01-cav-v1
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
@@ -71,7 +71,7 @@ spec:
               number: 5000
           weight: 100
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-13.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-13.expected.yaml
@@ -41,7 +41,7 @@ status:
     - test-cap-01-cav-v1
   observedGeneration: 2
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
@@ -76,7 +76,7 @@ spec:
               number: 5000
           weight: 100
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-15.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-15.expected.yaml
@@ -39,7 +39,7 @@ status:
   currentCAPApplicationVersionInstance: test-cap-01-cav-v2
   observedGeneration: 3
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
@@ -74,7 +74,7 @@ spec:
               number: 5000
           weight: 100
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-15.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-15.initial.yaml
@@ -39,7 +39,7 @@ status:
   currentCAPApplicationVersionInstance: test-cap-01-cav-v2
   observedGeneration: 2
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-16.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-16.expected.yaml
@@ -39,7 +39,7 @@ status:
   currentCAPApplicationVersionInstance: test-cap-01-cav-v2
   observedGeneration: 2
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-17.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-17.expected.yaml
@@ -39,7 +39,7 @@ status:
   currentCAPApplicationVersionInstance: test-cap-01-cav-v2
   observedGeneration: 3
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
@@ -74,7 +74,7 @@ spec:
               number: 5000
           weight: 100
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-17.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-17.initial.yaml
@@ -38,7 +38,7 @@ status:
   currentCAPApplicationVersionInstance: test-cap-01-cav-v2
   observedGeneration: 2
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
@@ -73,7 +73,7 @@ spec:
               number: 4000
           weight: 100
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-21.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-21.expected.yaml
@@ -42,7 +42,7 @@ status:
    - test-cap-01-cav-v1
   observedGeneration: 2
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-21.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-21.initial.yaml
@@ -75,7 +75,7 @@ status:
       type: Ready
   state: Completed
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/cat-22.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-22.initial.yaml
@@ -74,7 +74,7 @@ status:
       type: Ready
   state: Completed
 ---
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   labels:

--- a/internal/controller/testdata/captenant/provider-tenant-dr-v1.yaml
+++ b/internal/controller/testdata/captenant/provider-tenant-dr-v1.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: DestinationRule
 metadata:
   annotations:

--- a/internal/controller/testdata/captenant/provider-tenant-vs-v1.yaml
+++ b/internal/controller/testdata/captenant/provider-tenant-vs-v1.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:

--- a/internal/controller/testdata/common/operator-gateway.yaml
+++ b/internal/controller/testdata/common/operator-gateway.yaml
@@ -1,4 +1,4 @@
-apiVersion: networking.istio.io/v1beta1
+apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   generateName: cap-operator-domains-


### PR DESCRIPTION
Earlier this year [istio introduced v1 APIs](https://istio.io/latest/blog/2024/v1-apis/) for most of its networking resources. This is now used by our operator.