### PR TITLE
[Feat] Service type wehbook check enhancements

### DIFF
--- a/cmd/web-hooks/internal/handler/handler.go
+++ b/cmd/web-hooks/internal/handler/handler.go
@@ -28,18 +28,18 @@ import (
 )
 
 const (
-	LabelTenantType             = "sme.sap.com/tenant-type"
-	LabelTenantId               = "sme.sap.com/btp-tenant-id"
-	ProviderTenantType          = "provider"
-	SideCarEnv                  = "WEBHOOK_SIDE_CAR"
-	AdmissionError              = "admission error:"
-	InvalidResource             = "invalid resource"
-	InvalidationMessage         = "invalidated from webhook"
-	ValidationMessage           = "validated from webhook"
-	RequestPath                 = "/request"
-	DeploymentWorkloadCountErr  = "%s %s there should always be one workload deployment definition of type %s. Currently, there are %d workloads of type %s"
-	JobWorkloadCountErr         = "%s %s there should always be one workload job definition of type %s. Currently, there are %d workloads of type %s"
-	TenantOpJobWorkloadCountErr = "%s %s there should not be more than one workload job definition of type %s. Currently, there are %d workloads of type %s"
+	LabelTenantType                = "sme.sap.com/tenant-type"
+	LabelTenantId                  = "sme.sap.com/btp-tenant-id"
+	ProviderTenantType             = "provider"
+	SideCarEnv                     = "WEBHOOK_SIDE_CAR"
+	AdmissionError                 = "admission error:"
+	InvalidResource                = "invalid resource"
+	InvalidationMessage            = "invalidated from webhook"
+	ValidationMessage              = "validated from webhook"
+	RequestPath                    = "/request"
+	DeploymentWorkloadCountErr     = "%s %s there should always be one workload deployment definition of type %s. Currently, there are %d workloads of type %s"
+	TenantOpJobWorkloadCountErr    = "%s %s there should not be any job workload of type %s or %s defined if all the deployment workloads are of type %s."
+	ServiceExposureWorkloadNameErr = "%s %s workload name %s mentioned as part of routes in service exposure with subDomain %s is not valid."
 )
 
 type validateResource struct {
@@ -155,10 +155,10 @@ func checkWorkloadPort(workload *v1alpha1.WorkloadDetails) validateResource {
 }
 
 func checkWorkloadType(workload *v1alpha1.WorkloadDetails) validateResource {
-	if workload.DeploymentDefinition != nil && workload.DeploymentDefinition.Type != v1alpha1.DeploymentCAP && workload.DeploymentDefinition.Type != v1alpha1.DeploymentRouter && workload.DeploymentDefinition.Type != v1alpha1.DeploymentAdditional {
+	if workload.DeploymentDefinition != nil && workload.DeploymentDefinition.Type != v1alpha1.DeploymentCAP && workload.DeploymentDefinition.Type != v1alpha1.DeploymentRouter && workload.DeploymentDefinition.Type != v1alpha1.DeploymentAdditional && workload.DeploymentDefinition.Type != v1alpha1.DeploymentService {
 		return validateResource{
 			allowed: false,
-			message: fmt.Sprintf("%s %s invalid deployment definition type. Only supported - CAP, Router and Additional", InvalidationMessage, v1alpha1.CAPApplicationVersionKind),
+			message: fmt.Sprintf("%s %s invalid deployment definition type. Only supported - CAP, Router, Additional and Service", InvalidationMessage, v1alpha1.CAPApplicationVersionKind),
 		}
 	}
 
@@ -172,15 +172,26 @@ func checkWorkloadType(workload *v1alpha1.WorkloadDetails) validateResource {
 	return validAdmissionReviewObj()
 }
 
-func getWorkloadTypeCount(workloads []v1alpha1.WorkloadDetails) map[string]int {
+func getWorkloadTypeCount(workloads []v1alpha1.WorkloadDetails) (map[string]int, int) {
 	workloadTypeCount := make(map[string]int)
+	deploymentWorkloadCnt := 0
+
 	for _, workload := range workloads {
+
+		if workload.DeploymentDefinition != nil {
+			deploymentWorkloadCnt += 1
+		}
+
 		if workload.DeploymentDefinition != nil && workload.DeploymentDefinition.Type == v1alpha1.DeploymentCAP {
 			workloadTypeCount[string(v1alpha1.DeploymentCAP)] += 1
 		}
 
 		if workload.DeploymentDefinition != nil && workload.DeploymentDefinition.Type == v1alpha1.DeploymentRouter {
 			workloadTypeCount[string(v1alpha1.DeploymentRouter)] += 1
+		}
+
+		if workload.DeploymentDefinition != nil && workload.DeploymentDefinition.Type == v1alpha1.DeploymentService {
+			workloadTypeCount[string(v1alpha1.DeploymentService)] += 1
 		}
 
 		if workload.JobDefinition != nil && workload.JobDefinition.Type == v1alpha1.JobContent {
@@ -190,14 +201,30 @@ func getWorkloadTypeCount(workloads []v1alpha1.WorkloadDetails) map[string]int {
 		if workload.JobDefinition != nil && workload.JobDefinition.Type == v1alpha1.JobTenantOperation {
 			workloadTypeCount[string(v1alpha1.JobTenantOperation)] += 1
 		}
+
+		if workload.JobDefinition != nil && workload.JobDefinition.Type == v1alpha1.JobCustomTenantOperation {
+			workloadTypeCount[string(v1alpha1.JobCustomTenantOperation)] += 1
+		}
 	}
 
-	return workloadTypeCount
+	return workloadTypeCount, deploymentWorkloadCnt
 }
 
 func checkWorkloadTypeCount(cavObjNew *ResponseCav) validateResource {
 
-	workloadTypeCount := getWorkloadTypeCount(cavObjNew.Spec.Workloads)
+	workloadTypeCount, deploymentWorkloadCnt := getWorkloadTypeCount(cavObjNew.Spec.Workloads)
+
+	if workloadTypeCount[string(v1alpha1.DeploymentService)] == deploymentWorkloadCnt && (workloadTypeCount[string(v1alpha1.JobTenantOperation)] != 0 || workloadTypeCount[string(v1alpha1.JobCustomTenantOperation)] != 0) {
+		return validateResource{
+			allowed: false,
+			message: fmt.Sprintf(TenantOpJobWorkloadCountErr, InvalidationMessage, cavObjNew.Kind, v1alpha1.JobTenantOperation, v1alpha1.JobCustomTenantOperation, v1alpha1.DeploymentService),
+		}
+	}
+
+	// If there is atleast one service workload, no need to check for CAP and Router
+	if workloadTypeCount[string(v1alpha1.DeploymentService)] != 0 {
+		return validAdmissionReviewObj()
+	}
 
 	if workloadTypeCount[string(v1alpha1.DeploymentCAP)] != 1 {
 		return validateResource{
@@ -256,6 +283,29 @@ func checkWorkloadContentJob(cavObjNew *ResponseCav) validateResource {
 				return validateResource{
 					allowed: false,
 					message: fmt.Sprintf("%s %s job %s specified as part of ContentJobs is not a valid content job", InvalidationMessage, cavObjNew.Kind, job),
+				}
+			}
+		}
+	}
+
+	return validAdmissionReviewObj()
+}
+
+func checkServiceExposure(cavObjNew *ResponseCav) validateResource {
+	serviceDeploymentWorkloadNames := []string{}
+
+	for _, workload := range cavObjNew.Spec.Workloads {
+		if workload.DeploymentDefinition != nil && workload.DeploymentDefinition.Type == v1alpha1.DeploymentService {
+			serviceDeploymentWorkloadNames = append(serviceDeploymentWorkloadNames, workload.Name)
+		}
+	}
+
+	for _, serviceExposure := range cavObjNew.Spec.ServiceExposures {
+		for _, route := range serviceExposure.Routes {
+			if !slices.ContainsFunc(serviceDeploymentWorkloadNames, func(job string) bool { return job == route.WorkloadName }) {
+				return validateResource{
+					allowed: false,
+					message: fmt.Sprintf(ServiceExposureWorkloadNameErr, InvalidationMessage, cavObjNew.Kind, route.WorkloadName, serviceExposure.SubDomain),
 				}
 			}
 		}

--- a/cmd/web-hooks/internal/handler/handler.go
+++ b/cmd/web-hooks/internal/handler/handler.go
@@ -39,7 +39,7 @@ const (
 	RequestPath                    = "/request"
 	DeploymentWorkloadCountErr     = "%s %s there should always be one workload deployment definition of type %s. Currently, there are %d workloads of type %s"
 	TenantOpJobWorkloadCountErr    = "%s %s there should not be any job workload of type %s or %s defined if all the deployment workloads are of type %s."
-	ServiceExposureWorkloadNameErr = "%s %s workload name %s mentioned as part of routes in service exposure with subDomain %s is not valid."
+	ServiceExposureWorkloadNameErr = "%s %s workload name %s mentioned as part of routes in service exposure with subDomain %s is not a valid workload of type Service."
 )
 
 type validateResource struct {
@@ -528,6 +528,10 @@ func (wh *WebhookHandler) validateCAPApplicationVersion(w http.ResponseWriter, a
 
 		if workloadValidate := validateWorkloads(&cavObjNew); !workloadValidate.allowed {
 			return workloadValidate
+		}
+
+		if serviceExposureValidate := checkServiceExposure(&cavObjNew); !serviceExposureValidate.allowed {
+			return serviceExposureValidate
 		}
 
 		return validateTenantOperations(&cavObjNew)

--- a/cmd/web-hooks/internal/handler/handler.go
+++ b/cmd/web-hooks/internal/handler/handler.go
@@ -302,7 +302,7 @@ func checkServiceExposure(cavObjNew *ResponseCav) validateResource {
 
 	for _, serviceExposure := range cavObjNew.Spec.ServiceExposures {
 		for _, route := range serviceExposure.Routes {
-			if !slices.ContainsFunc(serviceDeploymentWorkloadNames, func(job string) bool { return job == route.WorkloadName }) {
+			if !slices.Contains(serviceDeploymentWorkloadNames, route.WorkloadName) {
 				return validateResource{
 					allowed: false,
 					message: fmt.Sprintf(ServiceExposureWorkloadNameErr, InvalidationMessage, cavObjNew.Kind, route.WorkloadName, serviceExposure.SubDomain),

--- a/cmd/web-hooks/internal/handler/handler_test.go
+++ b/cmd/web-hooks/internal/handler/handler_test.go
@@ -784,6 +784,8 @@ func TestCavInvalidity(t *testing.T) {
 		invalidJobinContentJobs            bool
 		invalidWorkloadName                bool
 		longWorkloadName                   bool
+		onlyServiceWorkloads               bool
+		serviceExposureWrongWorkloadName   bool
 		backlogItems                       []string
 	}{
 		{
@@ -885,6 +887,11 @@ func TestCavInvalidity(t *testing.T) {
 			operation:        admissionv1.Create,
 			longWorkloadName: true,
 			backlogItems:     []string{},
+		},
+		{
+			operation:            admissionv1.Create,
+			onlyServiceWorkloads: true,
+			backlogItems:         []string{},
 		},
 	}
 	for _, test := range tests {
@@ -1161,6 +1168,56 @@ func TestCavInvalidity(t *testing.T) {
 				crd.Spec.Workloads[0].Name = "WrongWorkloadName"
 			} else if test.longWorkloadName == true {
 				crd.Spec.Workloads[0].Name = "extralongworkloadnamecontainingmorethan64characters"
+			} else if test.onlyServiceWorkloads == true {
+				for _, workload := range crd.Spec.Workloads {
+					if workload.DeploymentDefinition != nil {
+						workload.DeploymentDefinition.Type = v1alpha1.DeploymentService
+					}
+				}
+
+				crd.Spec.Workloads = append(crd.Spec.Workloads, v1alpha1.WorkloadDetails{
+					Name:                "tenant-operation",
+					ConsumedBTPServices: []string{},
+					JobDefinition: &v1alpha1.JobDetails{
+						Type: v1alpha1.JobTenantOperation,
+						CommonDetails: v1alpha1.CommonDetails{
+							Image: "foo",
+						},
+					},
+				})
+
+				crd.Spec.Workloads = append(crd.Spec.Workloads, v1alpha1.WorkloadDetails{
+					Name:                "custom-tenant-operation",
+					ConsumedBTPServices: []string{},
+					JobDefinition: &v1alpha1.JobDetails{
+						Type: v1alpha1.JobCustomTenantOperation,
+						CommonDetails: v1alpha1.CommonDetails{
+							Image: "foo",
+						},
+					},
+				})
+			} else if test.serviceExposureWrongWorkloadName == true {
+				crd.Spec.Workloads = append(crd.Spec.Workloads, v1alpha1.WorkloadDetails{
+					Name:                "service-1",
+					ConsumedBTPServices: []string{},
+					DeploymentDefinition: &v1alpha1.DeploymentDetails{
+						Type: v1alpha1.DeploymentService,
+						CommonDetails: v1alpha1.CommonDetails{
+							Image: "foo",
+						},
+					},
+				})
+
+				crd.Spec.ServiceExposures = append(crd.Spec.ServiceExposures, v1alpha1.ServiceExposure{
+					SubDomain: "abc.com",
+					Routes: []v1alpha1.Route{
+						{
+							WorkloadName: "wrong-name",
+							Port:         4004,
+							Path:         "abc",
+						},
+					},
+				})
 			}
 
 			rawBytes, _ := json.Marshal(crd)
@@ -1185,7 +1242,7 @@ func TestCavInvalidity(t *testing.T) {
 			if test.duplicateWorkloadName == true {
 				errorMessage = fmt.Sprintf("%s %s duplicate workload name: cap-backend", InvalidationMessage, v1alpha1.CAPApplicationVersionKind)
 			} else if test.invalidDeploymentType == true {
-				errorMessage = fmt.Sprintf("%s %s invalid deployment definition type. Only supported - CAP, Router and Additional", InvalidationMessage, v1alpha1.CAPApplicationVersionKind)
+				errorMessage = fmt.Sprintf("%s %s invalid deployment definition type. Only supported - CAP, Router, Additional and Service", InvalidationMessage, v1alpha1.CAPApplicationVersionKind)
 			} else if test.invalidJobType == true {
 				errorMessage = fmt.Sprintf("%s %s invalid job definition type. Only supported - Content, TenantOperation and CustomTenantOperation", InvalidationMessage, v1alpha1.CAPApplicationVersionKind)
 			} else if test.onlyOneCAPTypeAllowed == true {
@@ -1222,6 +1279,10 @@ func TestCavInvalidity(t *testing.T) {
 				errorMessage = fmt.Sprintf("%s %s Invalid workload name: %s", InvalidationMessage, v1alpha1.CAPApplicationVersionKind, "WrongWorkloadName")
 			} else if test.longWorkloadName == true {
 				errorMessage = fmt.Sprintf("%s %s Derived service name: %s for workload %s will exceed 63 character limit. Adjust CAPApplicationVerion resource name or the workload name accordingly", InvalidationMessage, v1alpha1.CAPApplicationVersionKind, crd.Name+"-"+"extralongworkloadnamecontainingmorethan64characters"+"-svc", "extralongworkloadnamecontainingmorethan64characters")
+			} else if test.onlyServiceWorkloads == true {
+				errorMessage = fmt.Sprintf(TenantOpJobWorkloadCountErr, InvalidationMessage, v1alpha1.CAPApplicationVersionKind, v1alpha1.JobTenantOperation, v1alpha1.JobCustomTenantOperation, v1alpha1.DeploymentService)
+			} else if test.serviceExposureWrongWorkloadName == true {
+				errorMessage = fmt.Sprintf(ServiceExposureWorkloadNameErr, InvalidationMessage, v1alpha1.CAPApplicationVersionKind, crd.Spec.ServiceExposures[0].Routes[0].WorkloadName, crd.Spec.ServiceExposures[0].SubDomain)
 			}
 
 			if admissionReviewRes.Response.Allowed || admissionReviewRes.Response.Result.Message != errorMessage {

--- a/cmd/web-hooks/internal/handler/handler_test.go
+++ b/cmd/web-hooks/internal/handler/handler_test.go
@@ -893,6 +893,11 @@ func TestCavInvalidity(t *testing.T) {
 			onlyServiceWorkloads: true,
 			backlogItems:         []string{},
 		},
+		{
+			operation:                        admissionv1.Create,
+			serviceExposureWrongWorkloadName: true,
+			backlogItems:                     []string{},
+		},
 	}
 	for _, test := range tests {
 		nameParts := []string{"Testing CAPApplicationversion invalidity for operation " + string(test.operation) + "; "}


### PR DESCRIPTION
Checks implemented -

1. Allow `Service` type
2. Don't allow TenantOperation/CustomTenantOperation if all the workloads are of type `Service`
3. Check if the workload name is valid in the ServiceExposure. It should be of type `Service`