### PR TITLE
[FEATURE] Operator: Service type implemented

### DIFF
--- a/crds/sme.sap.com_capapplications.yaml
+++ b/crds/sme.sap.com_capapplications.yaml
@@ -120,7 +120,6 @@ spec:
             - btpAppName
             - domains
             - globalAccountId
-            - provider
             type: object
           status:
             properties:

--- a/crds/sme.sap.com_capapplications.yaml
+++ b/crds/sme.sap.com_capapplications.yaml
@@ -168,6 +168,8 @@ spec:
               observedGeneration:
                 format: int64
                 type: integer
+              servicesOnly:
+                type: boolean
               state:
                 enum:
                 - ""

--- a/internal/controller/reconcile-capapplication.go
+++ b/internal/controller/reconcile-capapplication.go
@@ -116,6 +116,8 @@ func (c *Controller) handleCAPApplicationDependentResources(ctx context.Context,
 	}
 	// Check if this is a services only scenario and update the Status accordingly
 	if err = c.checkServicesOnly(ca, cav); err != nil {
+		// Update additional condition `LatestVersionReady` to False with error from checkServicesOnly
+		ca.SetStatusCondition(string(v1alpha1.ConditionTypeLatestVersionReady), metav1.ConditionFalse, "WaitingForReadyCAPApplicationVersion", err.Error())
 		return
 	}
 	// We can already update LatestVersionReady to "true" at this point in time, but as this method is called several times, we do not do it here (during initial Provisioning as CA itself is may not be Consistent)

--- a/internal/controller/reconcile-capapplication.go
+++ b/internal/controller/reconcile-capapplication.go
@@ -94,7 +94,14 @@ func (c *Controller) handleCAPApplicationDependentResources(ctx context.Context,
 		return
 	}
 
-	// step 2 - check for valid versions
+	// step 2.1 Reconcile Service related DNS entries here --> This creates service exposure based DNS entries for all versions of the CAPApplication
+	// The version ready status needs these service related DNS entries to exist!
+	err = c.reconcileServiceDNSEntires(ctx, ca)
+	if err != nil {
+		return
+	}
+
+	// step 2.2 - check for valid versions
 	cav, err := c.getLatestReadyCAPApplicationVersion(ctx, ca, true)
 	if err != nil {
 		// do not update the CAPApplication status - this is not an error reported by the version, but error while fetching the version

--- a/internal/controller/reconcile-capapplication.go
+++ b/internal/controller/reconcile-capapplication.go
@@ -119,12 +119,17 @@ func (c *Controller) handleCAPApplicationDependentResources(ctx context.Context,
 		return
 	}
 
-	// step 5 - check state of dependent resources
+	// step 5 - reconile service exposure, create/update services based on the latest CAV
+	if requeue, err = c.reconcileServiceNetworking(ctx, ca, cav); requeue != nil || err != nil {
+		return
+	}
+
+	// step 6 - check state of dependent resources
 	if processing, err = c.checkPrimaryDomainResources(ctx, ca); err != nil || processing {
 		return
 	}
 
-	// step 6 - check and set consistent status
+	// step 7 - check and set consistent status
 	return c.verifyApplicationConsistent(ctx, ca)
 }
 

--- a/internal/controller/reconcile-capapplication_test.go
+++ b/internal/controller/reconcile-capapplication_test.go
@@ -65,6 +65,7 @@ func TestCAPApplicationWithValidSecret(t *testing.T) {
 			initialResources: []string{
 				"testdata/capapplication/ca-03.initial.yaml",
 				"testdata/common/credential-secrets.yaml",
+				"testdata/capapplication/istio-ingress-with-cert.yaml",
 			},
 			expectedResources: "testdata/capapplication/ca-03.expected.yaml",
 			expectedRequeue:   map[int][]NamespacedResourceKey{ResourceCAPApplication: {{Namespace: "default", Name: "test-cap-01"}}},
@@ -100,6 +101,7 @@ func TestValidationOfBtpServicesWithSecrets(t *testing.T) {
 			initialResources: []string{
 				"testdata/capapplication/ca-03.initial.yaml",
 				"testdata/common/credential-secrets.yaml",
+				"testdata/capapplication/istio-ingress-with-cert.yaml",
 			},
 			expectedResources: "testdata/capapplication/ca-03.expected.yaml",
 			attempts:          9999,

--- a/internal/controller/reconcile-capapplication_test.go
+++ b/internal/controller/reconcile-capapplication_test.go
@@ -1151,3 +1151,79 @@ func TestController_handleCAPApplicationConsistent_versionUpgrade(t *testing.T) 
 		},
 	)
 }
+
+func TestCA_ServicesOnly_Reconcile(t *testing.T) {
+	reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplication, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-ca-01"}},
+		TestData{
+			description: "capapplication - version with services only workload",
+			initialResources: []string{
+				"testdata/capapplication/ca-services.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/capapplication/gateway.yaml",
+				"testdata/capapplication/istio-ingress-with-cert.yaml",
+				"testdata/capapplication/ca-dns.yaml",
+				"testdata/capapplicationversion/expected/cav-services-ready.yaml",
+				"testdata/common/service-dns-entries.yaml",
+				"testdata/capapplicationversion/services-ready.yaml",
+				"testdata/capapplicationversion/service-content-job-completed.yaml",
+			},
+			backlogItems:      []string{},
+			expectError:       false,
+			expectedResources: "testdata/capapplication/ca-services-dns.yaml",
+			expectedRequeue:   map[int][]NamespacedResourceKey{ResourceCAPApplication: {{Namespace: "default", Name: "test-ca-01"}}},
+		},
+	)
+}
+
+func TestCA_ServicesOnlyÈrror(t *testing.T) {
+	reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplication, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-ca-01"}},
+		TestData{
+			description: "capapplication - version with services only workload",
+			initialResources: []string{
+				"testdata/capapplication/ca-services.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/common/operator-gateway.yaml",
+				"testdata/capapplication/gateway.yaml",
+				"testdata/capapplication/istio-ingress-with-cert.yaml",
+				"testdata/capapplication/ca-dns.yaml",
+				"testdata/capapplicationversion/expected/cav-services-ready.yaml",
+				"testdata/common/service-dns-entries.yaml",
+				"testdata/capapplicationversion/services-ready.yaml",
+				"testdata/capapplicationversion/service-content-job-completed.yaml",
+			},
+			backlogItems:      []string{},
+			expectError:       true,
+			expectedResources: "testdata/capapplication/ca-services-dns.yaml",
+		},
+	)
+}
+
+func TestCA_ServicesOnly_Consistent(t *testing.T) {
+	reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplication, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-ca-01"}},
+		TestData{
+			description: "capapplication - version with services only workload",
+			initialResources: []string{
+				"testdata/capapplication/ca-services.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/common/operator-gateway.yaml",
+				"testdata/capapplication/gateway.yaml",
+				"testdata/capapplication/istio-ingress-with-cert.yaml",
+				"testdata/capapplication/ca-dns.yaml",
+				"testdata/capapplicationversion/expected/cav-services-ready.yaml",
+				"testdata/common/service-dns-entries.yaml",
+				"testdata/common/service-virtualservices.yaml",
+				"testdata/capapplicationversion/services-ready.yaml",
+				"testdata/capapplicationversion/service-content-job-completed.yaml",
+			},
+			backlogItems:      []string{},
+			expectError:       false,
+			expectedResources: "testdata/capapplication/ca-services-dns-ready.yaml",
+		},
+	)
+}

--- a/internal/controller/reconcile-capapplicationversion.go
+++ b/internal/controller/reconcile-capapplicationversion.go
@@ -28,10 +28,7 @@ import (
 )
 
 const (
-	App                                             = "app"
-	EventActionReconcileServiceNetworking           = "ReconcileServiceNetworking"
-	CAVEventServiceNetworkingModified               = "ServiceNetworkingModified"
-	CAVEventServiceVirtualServiceModificationFailed = "ServiceVirtualServiceModificationFailed"
+	App = "app"
 )
 
 const (
@@ -135,13 +132,6 @@ func (c *Controller) handleCAPApplicationVersion(ctx context.Context, cav *v1alp
 		return nil, statusErr
 	}
 
-	// Create relevant DNSEntries for this version. DNS entries are checked before setting the version as ready
-	for _, serviceExposure := range cav.Spec.ServiceExposures {
-		if err = c.reconcileDNSEntries(ctx, serviceExposure.SubDomain, *metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind)), cav.Namespace, ca.Name, serviceExposure.SubDomain); err != nil {
-			return nil, err
-		}
-	}
-
 	return c.processWorkloads(ctx, ca, cav)
 }
 
@@ -213,12 +203,7 @@ func (c *Controller) processWorkloads(ctx context.Context, ca *v1alpha1.CAPAppli
 		return nil, err
 	}
 
-	requeue, err := c.reconcileServiceNetworking(ctx, cav, ca)
-	if requeue != nil || err != nil {
-		return requeue, err
-	}
-
-	requeue, err = c.checkServiceDNSEntries(ctx, ca, cav)
+	requeue, err := c.checkServiceDNSEntries(ctx, ca, cav)
 	if requeue != nil || err != nil {
 		return requeue, err
 	}
@@ -235,7 +220,7 @@ func (c *Controller) checkServiceDNSEntries(ctx context.Context, ca *v1alpha1.CA
 	checkNeeded := len(ca.Spec.Domains.Secondary) > 0 && len(cav.Spec.ServiceExposures) > 0
 	// Check for DNS entries
 	if checkNeeded {
-		processing, err := c.checkDNSEntries(ctx, v1alpha1.CAPApplicationVersionKind, cav.Namespace, cav.Name)
+		processing, err := c.checkDNSEntries(ctx, v1alpha1.CAPApplicationKind, ca.Namespace, ca.Name)
 		if err != nil {
 			util.LogError(err, "DNS entries error", string(Processing), cav, nil, "version", cav.Spec.Version)
 			return nil, err

--- a/internal/controller/reconcile-capapplicationversion.go
+++ b/internal/controller/reconcile-capapplicationversion.go
@@ -160,7 +160,9 @@ func (c *Controller) processWorkloads(ctx context.Context, ca *v1alpha1.CAPAppli
 		c.updateCAPApplicationVersionStatus(ctx, cav, v1alpha1.CAPApplicationVersionStateError, metav1.Condition{Type: string(v1alpha1.ConditionTypeReady), Status: "False", Reason: "ErrorInAppRouterDeployment", Message: err.Error()})
 		return nil, err
 	}
-	overallDeployments = append(overallDeployments, approuterDeployment)
+	if approuterDeployment != nil {
+		overallDeployments = append(overallDeployments, approuterDeployment)
+	}
 
 	// Create Server Deployment
 	serverDeployments, err := c.updateServerDeployment(ca, cav)
@@ -168,7 +170,9 @@ func (c *Controller) processWorkloads(ctx context.Context, ca *v1alpha1.CAPAppli
 		c.updateCAPApplicationVersionStatus(ctx, cav, v1alpha1.CAPApplicationVersionStateError, metav1.Condition{Type: string(v1alpha1.ConditionTypeReady), Status: "False", Reason: "ErrorInServerDeployment", Message: err.Error()})
 		return nil, err
 	}
-	overallDeployments = append(overallDeployments, serverDeployments...)
+	if len(serverDeployments) > 0 {
+		overallDeployments = append(overallDeployments, serverDeployments...)
+	}
 
 	// Create All Services
 	err = c.updateServices(ca, cav)
@@ -391,7 +395,10 @@ func (c *Controller) updateServerDeployment(ca *v1alpha1.CAPApplication, cav *v1
 // #region AppRouter
 func (c *Controller) updateApprouterDeployment(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion) (*appsv1.Deployment, error) {
 	routerWorkload := getRelevantDeployment(v1alpha1.DeploymentRouter, cav)
-	return c.updateDeployment(ca, cav, routerWorkload)
+	if routerWorkload != nil {
+		return c.updateDeployment(ca, cav, routerWorkload)
+	}
+	return nil, nil
 }
 
 //#endregion

--- a/internal/controller/reconcile-capapplicationversion_test.go
+++ b/internal/controller/reconcile-capapplicationversion_test.go
@@ -844,6 +844,93 @@ func TestCAV_InvalidMonitoringConfig(t *testing.T) {
 		},
 	)
 	if err == nil || err.Error() != fmt.Sprintf("invalid port reference in workload %s monitoring config of version %s", "app-router", "test-cap-01-cav-v1") {
-
+		t.FailNow()
 	}
+}
+
+func TestCAV_ServicesOnlyNoDNSEntries(t *testing.T) {
+	err := reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplicationVersion, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-ca-01-cav-v1"}},
+		TestData{
+			description: "capapplication version - services only workload",
+			initialResources: []string{
+				"testdata/common/ca-services.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/common/cav-services.yaml",
+				"testdata/capapplicationversion/services-ready.yaml",
+				"testdata/capapplicationversion/service-content-job-completed.yaml",
+			},
+			backlogItems:      []string{},
+			expectError:       true,
+			expectedResources: "testdata/capapplicationversion/expected/cav-services-missing-dns.yaml",
+		},
+	)
+	if err == nil || err.Error() != "No DNS entry found for CAPApplicationVersion default.test-ca-01-cav-v1" {
+		t.FailNow()
+	}
+}
+
+func TestCAV_ServicesOnly_DNSError(t *testing.T) {
+	reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplicationVersion, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-ca-01-cav-v1"}},
+		TestData{
+			description: "capapplication version - services only workload",
+			initialResources: []string{
+				"testdata/common/ca-services.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/common/cav-services.yaml",
+				"testdata/common/service-dns-entries-error.yaml",
+				"testdata/capapplicationversion/services-ready.yaml",
+				"testdata/capapplicationversion/service-content-job-completed.yaml",
+			},
+			backlogItems:      []string{},
+			expectError:       true,
+			expectedResources: "testdata/capapplicationversion/expected/cav-services-missing-dns.yaml",
+		},
+	)
+}
+
+func TestCAV_ServicesOnly_DNSPending(t *testing.T) {
+	reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplicationVersion, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-ca-01-cav-v1"}},
+		TestData{
+			description: "capapplication version - services only workload",
+			initialResources: []string{
+				"testdata/common/ca-services.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/common/cav-services.yaml",
+				"testdata/common/service-dns-entries-pending.yaml",
+				"testdata/capapplicationversion/services-ready.yaml",
+				"testdata/capapplicationversion/service-content-job-completed.yaml",
+			},
+			backlogItems:      []string{},
+			expectError:       false,
+			expectedResources: "testdata/capapplicationversion/expected/cav-services-missing-dns.yaml",
+			expectedRequeue:   map[int][]NamespacedResourceKey{ResourceCAPApplicationVersion: {{Namespace: "default", Name: "test-ca-01-cav-v1"}}},
+		},
+	)
+}
+
+func TestCAV_ServicesOnlySuccess(t *testing.T) {
+	reconcileTestItem(
+		context.TODO(), t,
+		QueueItem{Key: ResourceCAPApplicationVersion, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-ca-01-cav-v1"}},
+		TestData{
+			description: "capapplication version - services only workload",
+			initialResources: []string{
+				"testdata/common/ca-services.yaml",
+				"testdata/common/credential-secrets.yaml",
+				"testdata/common/cav-services.yaml",
+				"testdata/common/service-dns-entries.yaml",
+				"testdata/capapplicationversion/services-ready.yaml",
+				"testdata/capapplicationversion/service-content-job-completed.yaml",
+			},
+			backlogItems:      []string{},
+			expectError:       false,
+			expectedResources: "testdata/capapplicationversion/expected/cav-services-ready.yaml",
+		},
+	)
 }

--- a/internal/controller/reconcile-captenant.go
+++ b/internal/controller/reconcile-captenant.go
@@ -240,7 +240,7 @@ func (c *Controller) reconcileCAPTenant(ctx context.Context, item QueueItem, att
 
 	if cat.DeletionTimestamp == nil {
 		// Create relevant DNSEntries for this tenant. DNS entries are checked before setting the tenant as ready
-		if err = c.reconcileDNSEntries(ctx, cat.Name, *metav1.NewControllerRef(cat, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPTenantKind)), cat.Namespace, cat.Spec.CAPApplicationInstance, cat.Spec.SubDomain); err != nil {
+		if err = c.reconcileTenantDNSEntries(ctx, cat); err != nil {
 			return
 		}
 	}

--- a/internal/controller/reconcile-captenant.go
+++ b/internal/controller/reconcile-captenant.go
@@ -240,7 +240,7 @@ func (c *Controller) reconcileCAPTenant(ctx context.Context, item QueueItem, att
 
 	if cat.DeletionTimestamp == nil {
 		// Create relevant DNSEntries for this tenant. DNS entries are checked before setting the tenant as ready
-		if err = c.reconcileDNSEntries(ctx, *metav1.NewControllerRef(cat, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPTenantKind)), cat.Namespace, cat.Spec.CAPApplicationInstance, cat.Spec.SubDomain); err != nil {
+		if err = c.reconcileDNSEntries(ctx, cat.Name, *metav1.NewControllerRef(cat, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPTenantKind)), cat.Namespace, cat.Spec.CAPApplicationInstance, cat.Spec.SubDomain); err != nil {
 			return
 		}
 	}

--- a/internal/controller/reconcile-domains.go
+++ b/internal/controller/reconcile-domains.go
@@ -896,11 +896,12 @@ func (c *Controller) extractSubDomains(ctx context.Context, ca *v1alpha1.CAPAppl
 
 // Delete DNSEntries that are not in the current ServiceExposures list (TODO: may have to be done differently for service usage in multi-tenant scenarios)
 func (c *Controller) cleanupServiceDNSEntries(ctx context.Context, aSubDomainHashes []string, ca *v1alpha1.CAPApplication) (err error) {
-	// Add a requirement for OwnerIdentifierHash
+	// Add a requirement for OwnerIdentifierHash and SubdomainHash
 	ownerReq, _ := labels.NewRequirement(LabelOwnerIdentifierHash, selection.Equals, []string{sha1Sum(v1alpha1.CAPApplicationKind, ca.Namespace, ca.Name)})
-	// Create label selector based on the above requirement for filtering out all unused DNS entries
+	subDomainExistsReq, _ := labels.NewRequirement(LabelSubdomainHash, selection.Exists, []string{})
+	// Create label selector based on the above requirement for filtering out all unused service related DNS entries
 	labelSelector := labels.NewSelector()
-	labelSelector = labelSelector.Add(*ownerReq)
+	labelSelector = labelSelector.Add(*ownerReq, *subDomainExistsReq)
 
 	if len(aSubDomainHashes) > 0 {
 		// Add all unused subdomain hashes to requirements for Label Selector

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -38,6 +38,7 @@ const (
 	LabelCAVVersion                     = "sme.sap.com/cav-version"
 	LabelRelevantDNSTarget              = "sme.sap.com/relevant-dns-target-hash"
 	LabelDisableKarydia                 = "x4.sap.com/disable-karydia"
+	LabelSubdomainHash                  = "sme.sap.com/subdomain-hash"
 	AnnotationOwnerIdentifier           = "sme.sap.com/owner-identifier"
 	AnnotationBTPApplicationIdentifier  = "sme.sap.com/btp-app-identifier"
 	AnnotationResourceHash              = "sme.sap.com/resource-hash"

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -38,6 +38,7 @@ const (
 	LabelCAVVersion                     = "sme.sap.com/cav-version"
 	LabelRelevantDNSTarget              = "sme.sap.com/relevant-dns-target-hash"
 	LabelDisableKarydia                 = "x4.sap.com/disable-karydia"
+	LabelExposedWorkload                = "sme.sap.com/exposed-workload"
 	LabelSubdomainHash                  = "sme.sap.com/subdomain-hash"
 	AnnotationOwnerIdentifier           = "sme.sap.com/owner-identifier"
 	AnnotationBTPApplicationIdentifier  = "sme.sap.com/btp-app-identifier"

--- a/internal/controller/testdata/capapplication/ca-04.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-04.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-04.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-04.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-06.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-06.expected.yaml
@@ -53,5 +53,6 @@ status:
       status: "True"
       type: AllTenantsReady
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Consistent

--- a/internal/controller/testdata/capapplication/ca-06.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-06.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-07.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-07.expected.yaml
@@ -45,5 +45,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-08.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-08.expected.yaml
@@ -45,5 +45,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-09.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-09.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-09.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-09.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-10.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-10.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-10.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-10.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-11.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-11.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-11.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-11.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-12.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-12.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-12.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-12.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-21.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-21.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-21.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-21.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-23.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-23.expected.yaml
@@ -54,5 +54,6 @@ status:
       observedGeneration: 2
       status: "True"
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Consistent

--- a/internal/controller/testdata/capapplication/ca-23.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-23.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-24.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-24.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-25.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-25.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-26.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-26.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-26.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-26.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-27.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-27.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-27.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-27.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-28.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-28.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-28.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-28.initial.yaml
@@ -40,4 +40,5 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Processing"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-29.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-29.expected.yaml
@@ -40,6 +40,7 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: Consistent
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   conditions:
     - type: Ready

--- a/internal/controller/testdata/capapplication/ca-29.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-29.initial.yaml
@@ -40,6 +40,7 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Consistent"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   conditions:
     - type: Ready

--- a/internal/controller/testdata/capapplication/ca-30.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-30.expected.yaml
@@ -47,4 +47,5 @@ status:
       type: Ready
   observedGeneration: 0
   state: Processing
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-30.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-30.initial.yaml
@@ -42,4 +42,5 @@ status:
   conditions: []
   observedGeneration: 999
   state: "Consistent"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-31.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-31.expected.yaml
@@ -55,4 +55,5 @@ status:
       status: "False"
   observedGeneration: 0
   state: Processing
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-31.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-31.initial.yaml
@@ -41,4 +41,5 @@ spec:
 status:
   observedGeneration: 0
   state: "Consistent"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-32.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-32.expected.yaml
@@ -55,4 +55,5 @@ status:
       status: "False"
   observedGeneration: 0
   state: Processing
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-32.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-32.initial.yaml
@@ -41,4 +41,5 @@ spec:
 status:
   observedGeneration: 0
   state: "Consistent"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-33.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-33.expected.yaml
@@ -55,4 +55,5 @@ status:
       status: "False"
   observedGeneration: 0
   state: Processing
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-33.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-33.initial.yaml
@@ -41,4 +41,5 @@ spec:
 status:
   observedGeneration: 0
   state: "Consistent"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplication/ca-43.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-43.expected.yaml
@@ -46,5 +46,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Error

--- a/internal/controller/testdata/capapplication/ca-43.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-43.initial.yaml
@@ -44,5 +44,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-44.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-44.expected.yaml
@@ -45,5 +45,6 @@ status:
       status: "False"
       type: Ready
   observedGeneration: 2
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   state: Processing

--- a/internal/controller/testdata/capapplication/ca-45.expected.yaml
+++ b/internal/controller/testdata/capapplication/ca-45.expected.yaml
@@ -40,6 +40,7 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: Consistent
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   conditions:
     - type: Ready

--- a/internal/controller/testdata/capapplication/ca-45.initial.yaml
+++ b/internal/controller/testdata/capapplication/ca-45.initial.yaml
@@ -40,6 +40,7 @@ spec:
     tenantId: tenant-id-for-provider
 status:
   state: "Consistent"
+  servicesOnly: false
   domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
   conditions:
     - type: Ready

--- a/internal/controller/testdata/capapplication/ca-services-dns-ready.yaml
+++ b/internal/controller/testdata/capapplication/ca-services-dns-ready.yaml
@@ -1,0 +1,51 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplication
+metadata:
+  finalizers:
+    - sme.sap.com/capapplication
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+  generation: 0
+  name: test-ca-01
+  namespace: default
+  resourceVersion: "11373799"
+  uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+spec:
+  btp:
+    services:
+      - class: xsuaa
+        name: cap-uaa
+        secret: cap-cap-01-uaa-bind-cf
+      - class: xsuaa
+        name: cap-uaa2
+        secret: cap-cap-01-uaa2-bind-cf
+      - class: saas-registry
+        name: cap-saas-registry
+        secret: cap-cap-01-saas-bind-cf
+      - class: service-manager
+        name: cap-service-manager
+        secret: cap-cap-01-svc-man-bind-cf
+  btpAppName: test-cap-01
+  domains:
+    istioIngressGatewayLabels:
+      - name: app
+        value: istio-ingressgateway
+      - name: istio
+        value: ingressgateway
+    primary: app-domain.test.local
+    secondary:
+      - foo.bar.local
+  globalAccountId: btp-glo-acc-id
+status:
+  state: Consistent
+  servicesOnly: true
+  domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
+  conditions:
+    - reason: VersionExists
+      status: "True"
+      type: Ready
+    - reason: LatestVersionReady
+      status: "True"
+      type: LatestVersionReady

--- a/internal/controller/testdata/capapplication/ca-services-dns.yaml
+++ b/internal/controller/testdata/capapplication/ca-services-dns.yaml
@@ -1,0 +1,45 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplication
+metadata:
+  finalizers:
+    - sme.sap.com/capapplication
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+  generation: 0
+  name: test-ca-01
+  namespace: default
+  resourceVersion: "11373799"
+  uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+spec:
+  btp:
+    services:
+      - class: xsuaa
+        name: cap-uaa
+        secret: cap-cap-01-uaa-bind-cf
+      - class: xsuaa
+        name: cap-uaa2
+        secret: cap-cap-01-uaa2-bind-cf
+      - class: saas-registry
+        name: cap-saas-registry
+        secret: cap-cap-01-saas-bind-cf
+      - class: service-manager
+        name: cap-service-manager
+        secret: cap-cap-01-svc-man-bind-cf
+  btpAppName: test-cap-01
+  domains:
+    istioIngressGatewayLabels:
+      - name: app
+        value: istio-ingressgateway
+      - name: istio
+        value: ingressgateway
+    primary: app-domain.test.local
+    secondary:
+      - foo.bar.local
+  globalAccountId: btp-glo-acc-id
+status:
+  state: "Processing"
+  servicesOnly: true
+  domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8
+  conditions: []

--- a/internal/controller/testdata/capapplication/ca-services.yaml
+++ b/internal/controller/testdata/capapplication/ca-services.yaml
@@ -1,0 +1,43 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplication
+metadata:
+  finalizers:
+    - sme.sap.com/capapplication
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+  generation: 0
+  name: test-ca-01
+  namespace: default
+  resourceVersion: "11373799"
+  uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+spec:
+  btp:
+    services:
+      - class: xsuaa
+        name: cap-uaa
+        secret: cap-cap-01-uaa-bind-cf
+      - class: xsuaa
+        name: cap-uaa2
+        secret: cap-cap-01-uaa2-bind-cf
+      - class: saas-registry
+        name: cap-saas-registry
+        secret: cap-cap-01-saas-bind-cf
+      - class: service-manager
+        name: cap-service-manager
+        secret: cap-cap-01-svc-man-bind-cf
+  btpAppName: test-cap-01
+  domains:
+    istioIngressGatewayLabels:
+      - name: app
+        value: istio-ingressgateway
+      - name: istio
+        value: ingressgateway
+    primary: app-domain.test.local
+    secondary:
+      - foo.bar.local
+  globalAccountId: btp-glo-acc-id
+status:
+  state: "Processing"
+  domainSpecHash: 84fdeebf558412817f54b17a0158c6b6d53dda98e8bc7a887aaa7170296841f8

--- a/internal/controller/testdata/capapplicationversion/all-mulitple-content-job-completed.yaml
+++ b/internal/controller/testdata/capapplicationversion/all-mulitple-content-job-completed.yaml
@@ -188,6 +188,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/deployments-failure.yaml
+++ b/internal/controller/testdata/capapplicationversion/deployments-failure.yaml
@@ -57,6 +57,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/deployments-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/deployments-ready.yaml
@@ -45,6 +45,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-affinity.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-affinity.yaml
@@ -196,6 +196,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -219,6 +220,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -231,6 +233,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -356,7 +359,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-annotations.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-annotations.yaml
@@ -192,6 +192,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -212,6 +213,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -229,6 +231,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -339,7 +342,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-app-netpol.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-app-netpol.yaml
@@ -160,6 +160,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -183,6 +184,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -195,6 +197,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -302,7 +305,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-cluster-netpol-port.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-cluster-netpol-port.yaml
@@ -170,6 +170,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -193,6 +194,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -205,6 +207,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -312,7 +315,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-destination-config.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-destination-config.yaml
@@ -88,6 +88,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -111,6 +112,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -123,6 +125,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-labels-config.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-labels-config.yaml
@@ -120,6 +120,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -145,6 +146,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -159,6 +161,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-init.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-init.yaml
@@ -221,6 +221,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -244,6 +245,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -256,6 +258,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -418,7 +421,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-merged-destinations-router.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-merged-destinations-router.yaml
@@ -83,6 +83,8 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -106,6 +108,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -118,6 +121,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-prio.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-prio.yaml
@@ -180,6 +180,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -203,6 +204,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -215,6 +217,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -324,7 +327,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-selector.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-selector.yaml
@@ -180,6 +180,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -203,6 +204,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -215,6 +217,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -324,7 +327,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-pod-security-context.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-pod-security-context.yaml
@@ -184,6 +184,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -207,6 +208,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -219,6 +221,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -332,7 +335,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-probes-and-resources.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-probes-and-resources.yaml
@@ -160,6 +160,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -183,6 +184,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -195,6 +197,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-security-context.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-security-context.yaml
@@ -173,6 +173,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -196,6 +197,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -208,6 +210,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -318,7 +321,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-toleration.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-toleration.yaml
@@ -188,6 +188,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -211,6 +212,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -223,6 +225,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -340,7 +343,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-topology.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-topology.yaml
@@ -187,6 +187,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -210,6 +211,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -222,6 +224,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -338,7 +341,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-valid-env-config.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-valid-env-config.yaml
@@ -108,6 +108,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -131,6 +132,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -143,6 +145,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-vol.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-vol.yaml
@@ -189,6 +189,7 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
+    sme.sap.com/exposed-workload: "true"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
@@ -212,6 +213,7 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
@@ -224,6 +226,7 @@ spec:
         sme.sap.com/category: Workload
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
+        sme.sap.com/exposed-workload: "true"
         sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
@@ -342,7 +345,7 @@ spec:
       app: test-cap-01
       sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
-      sme.sap.com/workload-type: Router
+      sme.sap.com/exposed-workload: "true"
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:
     - Ingress

--- a/internal/controller/testdata/capapplicationversion/expected/cav-services-missing-dns.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-services-missing-dns.yaml
@@ -1,0 +1,86 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplicationVersion
+metadata:
+  creationTimestamp: "2022-03-18T22:14:33Z"
+  generation: 1
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+    sme.sap.com/owner-identifier: default.test-cap-01
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/owner-generation: "2"
+    sme.sap.com/owner-identifier-hash: 66ee9c21adb3f78f19a2c376acc179437a96b5cb
+  finalizers:
+    - sme.sap.com/capapplicationversion
+  name: test-ca-01-cav-v1
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+      uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+  resourceVersion: "11371108"
+  uid: 5e64489b-7346-4984-8617-e8c37338b3d8
+spec:
+  capApplicationInstance: test-ca-01
+  registrySecrets:
+    - regcred
+  version: 0.0.1
+  workloads:
+    - name: cap-backend-service
+      consumedBTPServices:
+        - cap-uaa
+        - cap-service-manager
+        - cap-saas-registry
+      deploymentDefinition:
+        type: Service
+        image: docker.image.repo/srv/server:latest
+        ports:
+          - name: server
+            port: 4004
+            appProtocol: http
+          - name: api
+            port: 8000
+            appProtocol: http
+          - name: metrics
+            port: 4005
+            appProtocol: http
+    - name: content-job
+      consumedBTPServices:
+        - cap-uaa
+      jobDefinition:
+        type: Content
+        image: docker.image.repo/content/cap-content:latest
+    - name: app-router
+      consumedBTPServices:
+        - cap-uaa
+        - cap-saas-registry
+      deploymentDefinition:
+        type: Service
+        image: docker.image.repo/approuter/approuter:latest
+        ports:
+          - name: server
+            port: 5000
+            appProtocol: http
+  serviceExposures:
+    - subDomain: router
+      routes:
+        - workloadName: app-router
+          port: 5000
+    - subDomain: api
+      routes:
+        - workloadName: cap-backend-service
+          port: 8000
+          path: /api
+status:
+  conditions:
+    - reason: WaitingForServiceDNSEntries
+      observedGeneration: 1
+      status: "False"
+      type: Ready
+  observedGeneration: 1
+  finishedJobs:
+    - test-ca-01-cav-v1-content
+  state: Processing

--- a/internal/controller/testdata/capapplicationversion/expected/cav-services-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-services-ready.yaml
@@ -1,0 +1,86 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplicationVersion
+metadata:
+  creationTimestamp: "2022-03-18T22:14:33Z"
+  generation: 1
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+    sme.sap.com/owner-identifier: default.test-cap-01
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/owner-generation: "2"
+    sme.sap.com/owner-identifier-hash: 66ee9c21adb3f78f19a2c376acc179437a96b5cb
+  finalizers:
+    - sme.sap.com/capapplicationversion
+  name: test-ca-01-cav-v1
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+      uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+  resourceVersion: "11371108"
+  uid: 5e64489b-7346-4984-8617-e8c37338b3d8
+spec:
+  capApplicationInstance: test-ca-01
+  registrySecrets:
+    - regcred
+  version: 0.0.1
+  workloads:
+    - name: cap-backend-service
+      consumedBTPServices:
+        - cap-uaa
+        - cap-service-manager
+        - cap-saas-registry
+      deploymentDefinition:
+        type: Service
+        image: docker.image.repo/srv/server:latest
+        ports:
+          - name: server
+            port: 4004
+            appProtocol: http
+          - name: api
+            port: 8000
+            appProtocol: http
+          - name: metrics
+            port: 4005
+            appProtocol: http
+    - name: content-job
+      consumedBTPServices:
+        - cap-uaa
+      jobDefinition:
+        type: Content
+        image: docker.image.repo/content/cap-content:latest
+    - name: app-router
+      consumedBTPServices:
+        - cap-uaa
+        - cap-saas-registry
+      deploymentDefinition:
+        type: Service
+        image: docker.image.repo/approuter/approuter:latest
+        ports:
+          - name: server
+            port: 5000
+            appProtocol: http
+  serviceExposures:
+    - subDomain: router
+      routes:
+        - workloadName: app-router
+          port: 5000
+    - subDomain: api
+      routes:
+        - workloadName: cap-backend-service
+          port: 8000
+          path: /api
+status:
+  conditions:
+    - reason: WorkloadsReady
+      observedGeneration: 1
+      status: "True"
+      type: Ready
+  observedGeneration: 1
+  finishedJobs:
+    - test-ca-01-cav-v1-content
+  state: Ready

--- a/internal/controller/testdata/capapplicationversion/service-content-job-completed.yaml
+++ b/internal/controller/testdata/capapplicationversion/service-content-job-completed.yaml
@@ -1,0 +1,71 @@
+apiVersion: batch/v1
+kind: Job
+metadata:
+  creationTimestamp: "2022-07-18T12:16:21Z"
+  labels:
+    job-name: test-ca-01-cav-v1-content
+  name: test-ca-01-cav-v1-content
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplicationVersion
+      name: test-ca-01-cav-v1-content
+      uid: 5e64489b-7346-4984-8617-e8c37338b3d8
+  resourceVersion: "150625273"
+  uid: afb8bcad-72ce-4567-8337-12fc67ef55acb
+spec:
+  backoffLimit: 2
+  completions: 1
+  parallelism: 1
+  selector:
+    matchLabels:
+      controller-uid: afb8bcad-72ce-4567-8337-12fc67ef55acb
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"
+      creationTimestamp: null
+      labels:
+        controller-uid: afb8bcad-72ce-4567-8337-12fc67ef55acb
+        job-name: test-ca-01-cav-v1-content
+        x4.sap.com/disable-karydia: "true"
+    spec:
+      containers:
+        - env:
+            - name: CAPOP_APP_VERSION
+              value: "0.0.1"
+            - name: TEST
+              value: Dummy
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  apiVersion: v1
+                  fieldPath: status.podIP
+          envFrom:
+            - secretRef:
+                name: test-ca-01-cav-v1-content-gen
+                optional: true
+          image: docker.image.repo/content/cap-content:latest
+          imagePullPolicy: Always
+          name: content-deploy
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      imagePullSecrets:
+        - name: regcred
+      restartPolicy: Never
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30
+status:
+  completionTime: "2022-07-18T12:16:41Z"
+  conditions:
+    - lastProbeTime: "2022-07-18T12:16:41Z"
+      lastTransitionTime: "2022-07-18T12:16:41Z"
+      status: "True"
+      type: Complete
+  startTime: "2022-07-14T12:16:21Z"
+  succeeded: 1

--- a/internal/controller/testdata/capapplicationversion/services-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/services-ready.yaml
@@ -1,0 +1,78 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-ca-01
+    sme.sap.com/category: Workload
+    sme.sap.com/workload-name: test-ca-01-cav-v1-cap-backend-service
+    sme.sap.com/workload-type: Service
+    sme.sap.com/exposed-workload: "true"
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/cav-version: "0.0.1"
+    sme.sap.com/owner-generation: "1"
+    sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-ca-01
+    sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
+  name: test-ca-01-cav-v1-cap-backend-service
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplicationVersion
+      name: test-ca-01-cav-v1
+      uid: 5e64489b-7346-4984-8617-e8c37338b3d8
+spec:
+status:
+  replicas: 1
+  updatedReplicas: 1
+  readyReplicas: 1
+  availableReplicas: 1
+  conditions:
+    - lastTransitionTime: "2022-07-18T12:16:41Z"
+      lastUpdateTime: "2022-07-18T12:16:41Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: test-ca-01
+    sme.sap.com/category: Workload
+    sme.sap.com/workload-name: test-ca-01-cav-v1-app-router
+    sme.sap.com/workload-type: Service
+    sme.sap.com/exposed-workload: "true"
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/cav-version: "0.0.1"
+    sme.sap.com/owner-generation: "1"
+    sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-ca-01
+    sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
+  name: test-ca-01-cav-v1-app-router
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplicationVersion
+      name: test-ca-01-cav-v1
+      uid: 5e64489b-7346-4984-8617-e8c37338b3d8
+spec:
+status:
+  replicas: 1
+  updatedReplicas: 1
+  readyReplicas: 1
+  availableReplicas: 1
+  conditions:
+    - lastTransitionTime: "2022-07-18T12:16:41Z"
+      lastUpdateTime: "2022-07-18T12:16:41Z"
+      message: Deployment has minimum availability.
+      reason: MinimumReplicasAvailable
+      status: "True"
+      type: Available

--- a/internal/controller/testdata/common/ca-services.yaml
+++ b/internal/controller/testdata/common/ca-services.yaml
@@ -1,0 +1,39 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplication
+metadata:
+  finalizers:
+    - sme.sap.com/capapplication
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+  name: test-ca-01
+  namespace: default
+  resourceVersion: "11373799"
+  uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+spec:
+  btp:
+    services:
+      - class: xsuaa
+        name: cap-uaa
+        secret: cap-cap-01-uaa-bind-cf
+      - class: xsuaa
+        name: cap-uaa2
+        secret: cap-cap-01-uaa2-bind-cf
+      - class: saas-registry
+        name: cap-saas-registry
+        secret: cap-cap-01-saas-bind-cf
+      - class: service-manager
+        name: cap-service-manager
+        secret: cap-cap-01-svc-man-bind-cf
+  btpAppName: test-cap-01
+  domains:
+    istioIngressGatewayLabels:
+      - name: app
+        value: istio-ingressgateway
+      - name: istio
+        value: ingressgateway
+    primary: app-domain.test.local
+    secondary:
+      - foo.bar.local
+  globalAccountId: btp-glo-acc-id

--- a/internal/controller/testdata/common/cav-services.yaml
+++ b/internal/controller/testdata/common/cav-services.yaml
@@ -1,0 +1,76 @@
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplicationVersion
+metadata:
+  creationTimestamp: "2022-03-18T22:14:33Z"
+  generation: 1
+  annotations:
+    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
+    sme.sap.com/owner-identifier: default.test-cap-01
+  labels:
+    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/owner-generation: "2"
+    sme.sap.com/owner-identifier-hash: 66ee9c21adb3f78f19a2c376acc179437a96b5cb
+  name: test-ca-01-cav-v1
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+      uid: 3c7ba7cb-dc04-4fd1-be86-3eb3a5c64a98
+  resourceVersion: "11371108"
+  uid: 5e64489b-7346-4984-8617-e8c37338b3d8
+spec:
+  capApplicationInstance: test-ca-01
+  registrySecrets:
+    - regcred
+  version: 0.0.1
+  workloads:
+    - name: cap-backend-service
+      consumedBTPServices:
+        - cap-uaa
+        - cap-service-manager
+        - cap-saas-registry
+      deploymentDefinition:
+        type: Service
+        image: docker.image.repo/srv/server:latest
+        ports:
+          - name: server
+            port: 4004
+            appProtocol: http
+          - name: api
+            port: 8000
+            appProtocol: http
+          - name: metrics
+            port: 4005
+            appProtocol: http
+    - name: content-job
+      consumedBTPServices:
+        - cap-uaa
+      jobDefinition:
+        type: Content
+        image: docker.image.repo/content/cap-content:latest
+    - name: app-router
+      consumedBTPServices:
+        - cap-uaa
+        - cap-saas-registry
+      deploymentDefinition:
+        type: Service
+        image: docker.image.repo/approuter/approuter:latest
+        ports:
+          - name: server
+            port: 5000
+            appProtocol: http
+  serviceExposures:
+    - subDomain: router
+      routes:
+        - workloadName: app-router
+          port: 5000
+    - subDomain: api
+      routes:
+        - workloadName: cap-backend-service
+          port: 8000
+          path: /api
+status:
+  state: Processing

--- a/internal/controller/testdata/common/service-dns-entries-error.yaml
+++ b/internal/controller/testdata/common/service-dns-entries-error.yaml
@@ -1,0 +1,49 @@
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+    sme.sap.com/resource-hash: be44dd98e914aa033f04f18a03338da45b40090b55e0e1c935353f088bd7c583
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+    sme.sap.com/owner-identifier-hash: 66ee9c21adb3f78f19a2c376acc179437a96b5cb
+  name: test-ca-01-router-dns
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  dnsName: "router.app-domain.test.local"
+  targets:
+    - public-ingress.operator.testing.local
+status:
+  state: Error
+  message: "dns message"
+---
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+    sme.sap.com/resource-hash: be44dd98e914aa033f04f18a03338da45b40090b55e0e1c935353f088bd7c583
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+    sme.sap.com/owner-identifier-hash: 489b013844088de243023d895aa4c674e90a4aad
+  name: test-ca-01-cap-backend-service-dns
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  dnsName: "cap-backend-service.app-domain.test.local"
+  targets:
+    - public-ingress.operator.testing.local
+status:
+  state: Error
+  message: "dns message"

--- a/internal/controller/testdata/common/service-dns-entries-pending.yaml
+++ b/internal/controller/testdata/common/service-dns-entries-pending.yaml
@@ -1,0 +1,47 @@
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+    sme.sap.com/resource-hash: be44dd98e914aa033f04f18a03338da45b40090b55e0e1c935353f088bd7c583
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+    sme.sap.com/owner-identifier-hash: 66ee9c21adb3f78f19a2c376acc179437a96b5cb
+  name: test-ca-01-router-dns
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  dnsName: "router.app-domain.test.local"
+  targets:
+    - public-ingress.operator.testing.local
+status:
+  state: Pending
+---
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+    sme.sap.com/resource-hash: be44dd98e914aa033f04f18a03338da45b40090b55e0e1c935353f088bd7c583
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+    sme.sap.com/owner-identifier-hash: 489b013844088de243023d895aa4c674e90a4aad
+  name: test-ca-01-cap-backend-service-dns
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  dnsName: "cap-backend-service.app-domain.test.local"
+  targets:
+    - public-ingress.operator.testing.local
+status:
+  state: Pending

--- a/internal/controller/testdata/common/service-dns-entries.yaml
+++ b/internal/controller/testdata/common/service-dns-entries.yaml
@@ -1,0 +1,51 @@
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+    sme.sap.com/resource-hash: be44dd98e914aa033f04f18a03338da45b40090b55e0e1c935353f088bd7c583
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+    sme.sap.com/owner-identifier-hash: 66ee9c21adb3f78f19a2c376acc179437a96b5cb
+  name: test-ca-01-router-dns
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  dnsName: "router.app-domain.test.local"
+  targets:
+    - public-ingress.operator.testing.local
+status:
+  state: Ready
+  targets:
+    - public-ingress.operator.testing.local
+---
+apiVersion: dns.gardener.cloud/v1alpha1
+kind: DNSEntry
+metadata:
+  annotations:
+    dns.gardener.cloud/class: garden
+    sme.sap.com/resource-hash: be44dd98e914aa033f04f18a03338da45b40090b55e0e1c935353f088bd7c583
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+    sme.sap.com/owner-identifier-hash: 489b013844088de243023d895aa4c674e90a4aad
+  name: test-ca-01-cap-backend-service-dns
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  dnsName: "cap-backend-service.app-domain.test.local"
+  targets:
+    - public-ingress.operator.testing.local
+status:
+  state: Ready
+  targets:
+    - public-ingress.operator.testing.local

--- a/internal/controller/testdata/common/service-virtualservices.yaml
+++ b/internal/controller/testdata/common/service-virtualservices.yaml
@@ -1,0 +1,67 @@
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  annotations:
+    sme.sap.com/resource-hash: "2309c27d407c5e1d71529d3448da227ab25f63fb5f9d631d7c8a3e9fd0a1ff34"
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+     sme.sap.com/owner-identifier-hash: 489b013844088de243023d895aa4c674e90a4aad
+  name: test-ca-01-router
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  gateways:
+    - test-cap-01-gw
+    - istio-system/cap-operator-domains-gen
+  hosts:
+    - router.app-domain.test.local
+    - router.foo.bar.local
+  http:
+    - match:
+        - uri:
+            prefix: /
+      route:
+        - destination:
+            host: test-ca-01-cav-v1-app-router-svc.default.svc.cluster.local
+            port:
+              number: 5000
+          weight: 100
+---
+apiVersion: networking.istio.io/v1
+kind: VirtualService
+metadata:
+  annotations:
+    sme.sap.com/resource-hash: "2309c27d407c5e1d71529d3448da227ab25f63fb5f9d631d7c8a3e9fd0a1ff34"
+    sme.sap.com/owner-identifier: CAPApplication.default.test-ca-01
+  labels:
+     sme.sap.com/owner-identifier-hash: 489b013844088de243023d895aa4c674e90a4aad
+  name: test-ca-01-cap-backend-service
+  namespace: default
+  ownerReferences:
+    - apiVersion: sme.sap.com/v1alpha1
+      blockOwnerDeletion: true
+      controller: true
+      kind: CAPApplication
+      name: test-ca-01
+spec:
+  gateways:
+    - test-cap-01-gw
+    - istio-system/cap-operator-domains-gen
+  hosts:
+    - cap-backend-service.app-domain.test.local
+    - cap-backend-service.foo.bar.local
+  http:
+    - match:
+        - uri:
+            prefix: /api
+      route:
+        - destination:
+            host: test-ca-01-cav-v1-cap-backend-service-svc.default.svc.cluster.local
+            port:
+              number: 8000
+          weight: 100

--- a/pkg/apis/sme.sap.com/v1alpha1/types.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/types.go
@@ -48,6 +48,8 @@ type CAPApplicationStatus struct {
 	// +kubebuilder:validation:Enum="";Consistent;Processing;Error;Deleting
 	// State of CAPApplication
 	State CAPApplicationState `json:"state"`
+	// Represents whether this is a services only scenario
+	ServicesOnly *bool `json:"servicesOnly,omitempty"`
 	// Hash representing last known application domains
 	DomainSpecHash string `json:"domainSpecHash,omitempty"`
 	// The last time a full reconciliation was completed

--- a/pkg/apis/sme.sap.com/v1alpha1/types.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/types.go
@@ -89,7 +89,7 @@ type CAPApplicationSpec struct {
 	// Short name for the application (similar to BTP XSAPPNAME)
 	BTPAppName string `json:"btpAppName"`
 	// Provider subaccount where application services are created
-	Provider BTPTenantIdentification `json:"provider"`
+	Provider BTPTenantIdentification `json:"provider,omitempty"`
 	// SAP BTP Services consumed by the application
 	BTP BTP `json:"btp"`
 }

--- a/pkg/apis/sme.sap.com/v1alpha1/utils.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/utils.go
@@ -30,6 +30,14 @@ func (ca *CAPApplication) SetStatusDomainSpecHash(hash string) {
 	ca.Status.DomainSpecHash = hash
 }
 
+func (ca *CAPApplication) SetStatusServicesOnly(val *bool) {
+	ca.Status.ServicesOnly = val
+}
+
+func (ca *CAPApplication) IsServicesOnly() bool {
+	return ca.Status.ServicesOnly != nil && *ca.Status.ServicesOnly
+}
+
 // SetStatusCondition updates/sets the conditions in the Status of the resource.
 func (ca *CAPApplication) SetStatusCondition(conditionType string, readyStatus metav1.ConditionStatus, reason string, message string) {
 	ca.Status.SetStatusCondition(metav1.Condition{Type: conditionType, Status: readyStatus, Reason: reason, Message: message, ObservedGeneration: ca.Generation})

--- a/pkg/apis/sme.sap.com/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/zz_generated.deepcopy.go
@@ -168,6 +168,11 @@ func (in *CAPApplicationSpec) DeepCopy() *CAPApplicationSpec {
 func (in *CAPApplicationStatus) DeepCopyInto(out *CAPApplicationStatus) {
 	*out = *in
 	in.GenericStatus.DeepCopyInto(&out.GenericStatus)
+	if in.ServicesOnly != nil {
+		in, out := &in.ServicesOnly, &out.ServicesOnly
+		*out = new(bool)
+		**out = **in
+	}
 	in.LastFullReconciliationTime.DeepCopyInto(&out.LastFullReconciliationTime)
 	return
 }

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/capapplicationstatus.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/capapplicationstatus.go
@@ -18,6 +18,7 @@ import (
 type CAPApplicationStatusApplyConfiguration struct {
 	GenericStatusApplyConfiguration `json:",inline"`
 	State                           *smesapcomv1alpha1.CAPApplicationState `json:"state,omitempty"`
+	ServicesOnly                    *bool                                  `json:"servicesOnly,omitempty"`
 	DomainSpecHash                  *string                                `json:"domainSpecHash,omitempty"`
 	LastFullReconciliationTime      *v1.Time                               `json:"lastFullReconciliationTime,omitempty"`
 }
@@ -54,6 +55,14 @@ func (b *CAPApplicationStatusApplyConfiguration) WithConditions(values ...*metav
 // If called multiple times, the State field is set to the value of the last call.
 func (b *CAPApplicationStatusApplyConfiguration) WithState(value smesapcomv1alpha1.CAPApplicationState) *CAPApplicationStatusApplyConfiguration {
 	b.State = &value
+	return b
+}
+
+// WithServicesOnly sets the ServicesOnly field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ServicesOnly field is set to the value of the last call.
+func (b *CAPApplicationStatusApplyConfiguration) WithServicesOnly(value bool) *CAPApplicationStatusApplyConfiguration {
+	b.ServicesOnly = &value
 	return b
 }
 


### PR DESCRIPTION
This change adds support for service only workloads (along with content jobs) which may be exposed directly to external traffic using `serviceExposures`