### PR TITLE
[Misc] Subscription: Saas Scope handling amended

### DIFF
--- a/cmd/server/internal/handler.go
+++ b/cmd/server/internal/handler.go
@@ -315,10 +315,11 @@ func (s *SubscriptionHandler) checkAuthorization(authHeader string, saasData *ut
 
 	token := authHeader[7:]
 	err := VerifyXSUAAJWTToken(context.TODO(), token, &XSUAAConfig{
-		UAADomain:      saasData.UAADomain,
-		ClientID:       saasData.ClientId,
-		XSAppName:      uaaData.XSAppName,
-		RequiredScopes: []string{uaaData.XSAppName + ".Callback", uaaData.XSAppName + ".mtcallback"},
+		UAADomain: saasData.UAADomain,
+		ClientID:  saasData.ClientId,
+		XSAppName: uaaData.XSAppName,
+		// `.Callback` is the scope usually used by approuter and `.mtcallback` is used by CAP. Either one of these may be present.
+		ExpectedScopes: []string{uaaData.XSAppName + ".Callback", uaaData.XSAppName + ".mtcallback"},
 	}, s.httpClientGenerator.NewHTTPClient())
 	if err != nil {
 		util.LogError(err, "failed token validation", step, "checkAuthorization", nil, "XSAppName", uaaData.XSAppName)

--- a/cmd/server/internal/jwt.go
+++ b/cmd/server/internal/jwt.go
@@ -27,8 +27,8 @@ type XSUAAConfig struct {
 	// one of xsappname OR clientid must be part of the audience
 	XSAppName string
 	ClientID  string
-	// all requested scopes must be fulfilled
-	RequiredScopes []string
+	// at least one expected scope must be fulfilled
+	ExpectedScopes []string
 }
 
 type XSUAAJWTClaims struct {
@@ -221,12 +221,12 @@ func adjustForNamespace(s []string, ignoreIfNotNamespaced bool) []string {
 func verifyScopes(claims *XSUAAJWTClaims, config *XSUAAConfig) bool {
 	scope := claims.Scope
 	tokenScope := convertToMap(scope)
-	for _, expected := range config.RequiredScopes {
-		if _, ok := tokenScope[expected]; !ok {
-			return false // all expected scopes should match
+	for _, expected := range config.ExpectedScopes {
+		if _, ok := tokenScope[expected]; ok {
+			return true // at least 1 expected scope should match
 		}
 	}
-	return true
+	return false
 }
 
 // Create a dummy lookup map

--- a/cmd/server/internal/jwt_test.go
+++ b/cmd/server/internal/jwt_test.go
@@ -63,7 +63,7 @@ func SetupValidTokenAndIssuerForSubscriptionTests(xsappname string) (*http.Clien
 		UAADomain:      jwtTestUAADomain,
 		XSAppName:      xsappname,
 		ClientID:       "some-client-id",
-		RequiredScopes: []string{xsappname + ".Callback", xsappname + ".mtcallback"},
+		ExpectedScopes: []string{xsappname + ".Callback"},
 	}, &jwtTestParameters{})
 }
 
@@ -83,7 +83,7 @@ func setupTokenAndIssuer(config *XSUAAConfig, params *jwtTestParameters) (*http.
 		return nil, "", fmt.Errorf("error generating rsa key: %s", err.Error())
 	}
 	claims := XSUAAJWTClaims{
-		Scope:           config.RequiredScopes,
+		Scope:           config.ExpectedScopes,
 		ClientID:        brokerApp,
 		AuthorizedParty: brokerApp,
 		RegisteredClaims: jwt.RegisteredClaims{
@@ -199,7 +199,7 @@ var testXSUAAConfig *XSUAAConfig = &XSUAAConfig{
 	UAADomain:      jwtTestUAADomain,
 	XSAppName:      "myxsappname",
 	ClientID:       "some-client-id",
-	RequiredScopes: []string{"myxsappname.Callback", "myxsappname.mtcallback"},
+	ExpectedScopes: []string{"myxsappname.mtcallback"},
 }
 
 func testVerifyValidToken(t *testing.T) {
@@ -218,7 +218,7 @@ func testValidTokenWithBrokerClientId(t *testing.T) {
 	brokerXSUAAConfig := &XSUAAConfig{
 		UAADomain:      testXSUAAConfig.UAADomain,
 		ClientID:       testXSUAAConfig.ClientID,
-		RequiredScopes: testXSUAAConfig.RequiredScopes,
+		ExpectedScopes: testXSUAAConfig.ExpectedScopes,
 		XSAppName:      "xsapp!b4711",
 	}
 	client, tokenString, err := setupTokenAndIssuer(brokerXSUAAConfig, &jwtTestParameters{clientIsBroker: true})


### PR DESCRIPTION
Scope handling in the subscription service has been amended to support either `.Callback` or `.mtCallback` in the JWT token. This allows most apps to transition easily, as one of these is usually present already.