### PR TITLE
[Misc] Domain resources handling amended

### DIFF
--- a/crds/sme.sap.com_clusterdomains.yaml
+++ b/crds/sme.sap.com_clusterdomains.yaml
@@ -107,6 +107,8 @@ spec:
                 type: array
               dnsTarget:
                 type: string
+              gatewayName:
+                type: string
               observedDomain:
                 type: string
               observedGeneration:

--- a/crds/sme.sap.com_domains.yaml
+++ b/crds/sme.sap.com_domains.yaml
@@ -107,6 +107,8 @@ spec:
                 type: array
               dnsTarget:
                 type: string
+              gatewayName:
+                type: string
               observedDomain:
                 type: string
               observedGeneration:

--- a/internal/controller/testdata/captenant/cat-04.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-04.expected.yaml
@@ -40,7 +40,7 @@ apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
-    sme.sap.com/resource-hash: c280c17a7d333e1e021bf607951133eeb94506e7c02b2d8d07a858d4fe8818ee
+    sme.sap.com/resource-hash: 095aa539f02dffd3044dbd6d7d00f1a6d564791fecf6d5477dd9a7b320098d68
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "0"
@@ -55,8 +55,8 @@ metadata:
       name: test-cap-01-provider
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - my-provider.app-domain.test.local
     - my-provider.foo.bar.local

--- a/internal/controller/testdata/captenant/cat-13.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-13.expected.yaml
@@ -45,7 +45,7 @@ apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
-    sme.sap.com/resource-hash: 1d2d693ed3ca2d83db03c6615724c011bf2beb944870d2109976a97e21cdd878
+    sme.sap.com/resource-hash: ac57fa31ed22c65186a46b7110cb1504999edc415eb29193765e7f170322baa7
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "2"
@@ -60,8 +60,8 @@ metadata:
       name: test-cap-01-provider
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - my-provider.app-domain.test.local
     - my-provider.foo.bar.local

--- a/internal/controller/testdata/captenant/cat-15.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-15.expected.yaml
@@ -43,7 +43,7 @@ apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
-    sme.sap.com/resource-hash: 7121d80349eec52372c6bf8c85dfc2254140efe0cb4c87ff24cfcf3a1b7d7524
+    sme.sap.com/resource-hash: 8df0b98845421e51a49224b76d6cc675ca39858ebedcfa48264bdbe0cfff47a1
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "3"
@@ -58,8 +58,8 @@ metadata:
       name: test-cap-01-provider
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - my-changed-provider.app-domain.test.local
     - my-changed-provider.foo.bar.local

--- a/internal/controller/testdata/captenant/cat-21.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-21.expected.yaml
@@ -46,7 +46,7 @@ apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
-    sme.sap.com/resource-hash: 1d2d693ed3ca2d83db03c6615724c011bf2beb944870d2109976a97e21cdd878
+    sme.sap.com/resource-hash: ac57fa31ed22c65186a46b7110cb1504999edc415eb29193765e7f170322baa7
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "2"
@@ -61,8 +61,8 @@ metadata:
       name: test-cap-01-provider
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - my-provider.app-domain.test.local
     - my-provider.foo.bar.local

--- a/internal/controller/testdata/captenant/cat-30.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-30.expected.yaml
@@ -43,7 +43,7 @@ apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
-    sme.sap.com/resource-hash: 1307a6df7bc92b37a6d3431accd61cc7b4b5939f136b2a7e1c72def31f6f7538
+    sme.sap.com/resource-hash: 062862a74cd12051b3817b786a218ff00aad40d6d223da4d0222add0287420a5
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "3"
@@ -58,8 +58,8 @@ metadata:
       name: test-cap-01-provider
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - my-changed-provider.app-domain.test.local
     - my-changed-provider.foo.bar.local

--- a/internal/controller/testdata/captenant/cat-30.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-30.initial.yaml
@@ -43,7 +43,7 @@ apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
-    sme.sap.com/resource-hash: 7121d80349eec52372c6bf8c85dfc2254140efe0cb4c87ff24cfcf3a1b7d7524
+    sme.sap.com/resource-hash: 8df0b98845421e51a49224b76d6cc675ca39858ebedcfa48264bdbe0cfff47a1
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "3"
@@ -58,8 +58,8 @@ metadata:
       name: test-cap-01-provider
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - my-changed-provider.app-domain.test.local
     - my-changed-provider.foo.bar.local

--- a/internal/controller/testdata/captenant/provider-tenant-vs-v1.yaml
+++ b/internal/controller/testdata/captenant/provider-tenant-vs-v1.yaml
@@ -2,7 +2,7 @@ apiVersion: networking.istio.io/v1
 kind: VirtualService
 metadata:
   annotations:
-    sme.sap.com/resource-hash: c280c17a7d333e1e021bf607951133eeb94506e7c02b2d8d07a858d4fe8818ee
+    sme.sap.com/resource-hash: 095aa539f02dffd3044dbd6d7d00f1a6d564791fecf6d5477dd9a7b320098d68
     sme.sap.com/owner-identifier: default.test-cap-01-provider
   labels:
     sme.sap.com/owner-generation: "0"
@@ -17,8 +17,8 @@ metadata:
       name: test-cap-01-provider
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - my-provider.app-domain.test.local
     - my-provider.foo.bar.local

--- a/internal/controller/testdata/common/cluster-domain-ready.yaml
+++ b/internal/controller/testdata/common/cluster-domain-ready.yaml
@@ -19,6 +19,7 @@ status:
     type: Ready
   dnsTarget: x.bar.local
   observedDomain: foo.bar.local
+  gatewayName: test-cap-01-secondary-gen
   observedGeneration: 1
   state: Ready
 

--- a/internal/controller/testdata/common/domain-hostUpdated-ready.yaml
+++ b/internal/controller/testdata/common/domain-hostUpdated-ready.yaml
@@ -20,5 +20,6 @@ status:
     type: Ready
   dnsTarget: x.test.local
   observedDomain: app-domain-dup.test.local
+  gatewayName: test-cap-01-primary-gen
   observedGeneration: 1
   state: Ready

--- a/internal/controller/testdata/common/domain-ready.yaml
+++ b/internal/controller/testdata/common/domain-ready.yaml
@@ -20,5 +20,6 @@ status:
     type: Ready
   dnsTarget: x.test.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen
   observedGeneration: 1
   state: Ready

--- a/internal/controller/testdata/common/service-virtualservices.yaml
+++ b/internal/controller/testdata/common/service-virtualservices.yaml
@@ -16,8 +16,8 @@ metadata:
       name: test-ca-01
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - router.app-domain.test.local
     - router.foo.bar.local
@@ -50,8 +50,8 @@ metadata:
       name: test-ca-01
 spec:
   gateways:
-    - default-test-cap-01-primary
-    - default/default-test-cap-01-secondary
+    - test-cap-01-primary-gen
+    - default/test-cap-01-secondary-gen
   hosts:
     - api.app-domain.test.local
     - api.foo.bar.local

--- a/internal/controller/testdata/domain/domain-cert-error.yaml
+++ b/internal/controller/testdata/domain/domain-cert-error.yaml
@@ -23,3 +23,4 @@ status:
   state: Error
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: "test-cap-01-primary-gen"

--- a/internal/controller/testdata/domain/domain-certManager-error.yaml
+++ b/internal/controller/testdata/domain/domain-certManager-error.yaml
@@ -23,3 +23,4 @@ status:
   state: Error
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-deleting-no-finalizer.yaml
+++ b/internal/controller/testdata/domain/domain-deleting-no-finalizer.yaml
@@ -22,3 +22,4 @@ status:
   state: Deleting
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-deleting.yaml
+++ b/internal/controller/testdata/domain/domain-deleting.yaml
@@ -24,3 +24,4 @@ status:
   state: Deleting
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-dns-error.yaml
+++ b/internal/controller/testdata/domain/domain-dns-error.yaml
@@ -23,3 +23,4 @@ status:
   state: Error
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-processing-dns.yaml
+++ b/internal/controller/testdata/domain/domain-processing-dns.yaml
@@ -23,6 +23,7 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen
 ---
 apiVersion: dns.gardener.cloud/v1alpha1
 kind: DNSEntry
@@ -31,13 +32,13 @@ metadata:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: bcec92268a567aadc243d28dda4ad857a41a858964b920c77f6376849e660419
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/subdomain-hash: df58248c414f342c81e056b40bee12d17a08bf61
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1

--- a/internal/controller/testdata/domain/domain-processing-observedDom-cert-gateway.yaml
+++ b/internal/controller/testdata/domain/domain-processing-observedDom-cert-gateway.yaml
@@ -23,17 +23,19 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen
 ---
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 88fee3ef7f6c6ad863d66d5932953b7303e4494574ad594a40cfd0894834e34d
+    sme.sap.com/resource-hash: 867335af5f55d7a37c7309833ce135deb875531b2db7efbcd9b831debd1190e0
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
+  name: test-cap-01-primary-gen
+  generateName: test-cap-01-primary-
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1
@@ -53,7 +55,7 @@ spec:
       number: 443
       protocol: HTTPS
     tls:
-      credentialName: default-test-cap-01-primary
+      credentialName: default--test-cap-01-primary
       mode: SIMPLE
 ---
 apiVersion: cert.gardener.cloud/v1alpha1
@@ -61,18 +63,19 @@ kind: Certificate
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 4f15ef7b54d820e54dc376eb08324a635c40dec81e6cc5593fb4ece81c8da776
+    sme.sap.com/resource-hash: 8e560670061f2ae8314cf2fdfa272b620bfb6420653bf806b43dee4091c29ea2
   finalizers:
   - sme.sap.com/domain
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
-  namespace: istio-system
+  name: test-cap-01-primary-gen
+  generateName: test-cap-01-primary-
+  namespace: default
 spec:
   dnsNames:
   - '*.app-domain.test.local'
   secretRef:
-    name: default-test-cap-01-primary
+    name: default--test-cap-01-primary
     namespace: istio-system
 

--- a/internal/controller/testdata/domain/domain-processing-observedDom-certManager-gateway.yaml
+++ b/internal/controller/testdata/domain/domain-processing-observedDom-certManager-gateway.yaml
@@ -23,17 +23,19 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen
 ---
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 88fee3ef7f6c6ad863d66d5932953b7303e4494574ad594a40cfd0894834e34d
+    sme.sap.com/resource-hash: 867335af5f55d7a37c7309833ce135deb875531b2db7efbcd9b831debd1190e0
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
+  name: test-cap-01-primary-gen
+  generateName: test-cap-01-primary-
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1
@@ -53,7 +55,7 @@ spec:
       number: 443
       protocol: HTTPS
     tls:
-      credentialName: default-test-cap-01-primary
+      credentialName: default--test-cap-01-primary
       mode: SIMPLE
 ---
 apiVersion: cert-manager.io/v1
@@ -61,18 +63,18 @@ kind: Certificate
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 4f15ef7b54d820e54dc376eb08324a635c40dec81e6cc5593fb4ece81c8da776
+    sme.sap.com/resource-hash: 8e560670061f2ae8314cf2fdfa272b620bfb6420653bf806b43dee4091c29ea2
   finalizers:
   - sme.sap.com/domain
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
+  name: default--test-cap-01-primary
   namespace: istio-system
 spec:
   dnsNames:
   - '*.app-domain.test.local'
-  secretName: default-test-cap-01-primary
+  secretName: default--test-cap-01-primary
   issuerRef:
     kind: ClusterIssuer
     name: cluster-ca

--- a/internal/controller/testdata/domain/domain-processing-observedDom.yaml
+++ b/internal/controller/testdata/domain/domain-processing-observedDom.yaml
@@ -23,3 +23,4 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-ready-withDeletionTimestamp.yaml
+++ b/internal/controller/testdata/domain/domain-ready-withDeletionTimestamp.yaml
@@ -24,3 +24,4 @@ status:
   state: Ready
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-ready.yaml
+++ b/internal/controller/testdata/domain/domain-ready.yaml
@@ -23,3 +23,4 @@ status:
   state: Ready
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-update.expected.yaml
+++ b/internal/controller/testdata/domain/domain-update.expected.yaml
@@ -23,17 +23,18 @@ status:
   state: Ready
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain-dup.test.local
+  gatewayName: test-cap-01-primary-gen
 ---
 apiVersion: networking.istio.io/v1
 kind: Gateway
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 0d321fe553b796574ea521b052a525a9f04dde2579d173240c1db691cea24d51
+    sme.sap.com/resource-hash: 2671644b10d903aaa24c2a7b8fd01005169967dfda43b4ea947c7f388c42bcf4
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1
@@ -53,7 +54,7 @@ spec:
       number: 443
       protocol: HTTPS
     tls:
-      credentialName: default-test-cap-01-primary
+      credentialName: default--test-cap-01-primary
       mode: SIMPLE
 ---
 apiVersion: dns.gardener.cloud/v1alpha1
@@ -63,13 +64,13 @@ metadata:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: d9ccf51ead1f6a2c8634259f546de958bae8f91183fc453f52157fd60248cfab
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/subdomain-hash: df58248c414f342c81e056b40bee12d17a08bf61
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1

--- a/internal/controller/testdata/domain/domain-update.yaml
+++ b/internal/controller/testdata/domain/domain-update.yaml
@@ -23,3 +23,4 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain-dup.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol-cat.yaml
+++ b/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol-cat.yaml
@@ -23,6 +23,7 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen
 ---
 apiVersion: dns.gardener.cloud/v1alpha1
 kind: DNSEntry
@@ -31,13 +32,13 @@ metadata:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: 457a39429f9c4094728569ea35ea819e6425ee9d56de3e2d054df5d41dda50f3
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/btp-app-identifier-hash: "f20cc8aeb2003b3abc33f749a16bd53544b6bab2"
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/subdomain-hash: 7a83a2611021dafaee3f3c3d01ab81ba30189948
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1
@@ -60,11 +61,11 @@ metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: 5b5634ce9ed5d6e0944ab5fa99a8ce5449376977093569bfbf38228f9da48615
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1

--- a/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol.yaml
+++ b/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol.yaml
@@ -23,6 +23,7 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen
 ---
 apiVersion: dns.gardener.cloud/v1alpha1
 kind: DNSEntry
@@ -31,13 +32,13 @@ metadata:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: 4771a56b83e1d5c230c81d27a14bfd408f82c5c1daa02271c61c2058047aab9f
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/btp-app-identifier-hash: "f20cc8aeb2003b3abc33f749a16bd53544b6bab2"
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/subdomain-hash: a033a528b603fed46f861d4b3542c417b99d41c8
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1
@@ -60,11 +61,11 @@ metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: 5b5634ce9ed5d6e0944ab5fa99a8ce5449376977093569bfbf38228f9da48615
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1

--- a/internal/controller/testdata/domain/domain-with-subdomain-processing.yaml
+++ b/internal/controller/testdata/domain/domain-with-subdomain-processing.yaml
@@ -23,3 +23,4 @@ status:
   state: Processing
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/domain-with-subdomain-ready.yaml
+++ b/internal/controller/testdata/domain/domain-with-subdomain-ready.yaml
@@ -23,3 +23,4 @@ status:
   state: Ready
   dnsTarget: public-ingress.operator.testing.local
   observedDomain: app-domain.test.local
+  gatewayName: test-cap-01-primary-gen

--- a/internal/controller/testdata/domain/primary-certManager-error.yaml
+++ b/internal/controller/testdata/domain/primary-certManager-error.yaml
@@ -5,14 +5,14 @@ metadata:
   namespace: istio-system
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 4f15ef7b54d820e54dc376eb08324a635c40dec81e6cc5593fb4ece81c8da776
+    sme.sap.com/resource-hash: 8e560670061f2ae8314cf2fdfa272b620bfb6420653bf806b43dee4091c29ea2
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
 spec:
   dnsNames:
   - '*.app-domain.test.local'
-  secretName: default-test-cap-01-primary
+  secretName: default--test-cap-01-primary
   issuerRef:
     kind: ClusterIssuer
     name: cluster-ca

--- a/internal/controller/testdata/domain/primary-certManager-ready.yaml
+++ b/internal/controller/testdata/domain/primary-certManager-ready.yaml
@@ -5,14 +5,14 @@ metadata:
   namespace: istio-system
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 4f15ef7b54d820e54dc376eb08324a635c40dec81e6cc5593fb4ece81c8da776
+    sme.sap.com/resource-hash: 8e560670061f2ae8314cf2fdfa272b620bfb6420653bf806b43dee4091c29ea2
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
 spec:
   dnsNames:
   - '*.app-domain.test.local'
-  secretName: default-test-cap-01-primary
+  secretName: default--test-cap-01-primary
   issuerRef:
     kind: ClusterIssuer
     name: cluster-ca

--- a/internal/controller/testdata/domain/primary-certificate-error.yaml
+++ b/internal/controller/testdata/domain/primary-certificate-error.yaml
@@ -3,20 +3,20 @@ kind: Certificate
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 4f15ef7b54d820e54dc376eb08324a635c40dec81e6cc5593fb4ece81c8da776
+    sme.sap.com/resource-hash: 8e560670061f2ae8314cf2fdfa272b620bfb6420653bf806b43dee4091c29ea2
   finalizers:
   - sme.sap.com/domain
   generation: 1
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
-  namespace: istio-system
+  name: test-cap-01-primary-gen
+  namespace: default
 spec:
   dnsNames:
   - '*.app-domain.test.local'
   secretRef:
-    name: default-test-cap-01-primary
+    name: default--test-cap-01-primary
     namespace: istio-system
 status:
   state: Error

--- a/internal/controller/testdata/domain/primary-certificate-ready.yaml
+++ b/internal/controller/testdata/domain/primary-certificate-ready.yaml
@@ -3,20 +3,20 @@ kind: Certificate
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 4f15ef7b54d820e54dc376eb08324a635c40dec81e6cc5593fb4ece81c8da776
+    sme.sap.com/resource-hash: 8e560670061f2ae8314cf2fdfa272b620bfb6420653bf806b43dee4091c29ea2
   finalizers:
   - sme.sap.com/domain
   generation: 1
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
-  namespace: istio-system
+  name: test-cap-01-primary-gen
+  namespace: default
 spec:
   dnsNames:
   - '*.app-domain.test.local'
   secretRef:
-    name: default-test-cap-01-primary
+    name: default--test-cap-01-primary
     namespace: istio-system
 status:
   state: Ready

--- a/internal/controller/testdata/domain/primary-dns-error.yaml
+++ b/internal/controller/testdata/domain/primary-dns-error.yaml
@@ -5,13 +5,13 @@ metadata:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: bcec92268a567aadc243d28dda4ad857a41a858964b920c77f6376849e660419
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/subdomain-hash: df58248c414f342c81e056b40bee12d17a08bf61
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1

--- a/internal/controller/testdata/domain/primary-dns-ready.yaml
+++ b/internal/controller/testdata/domain/primary-dns-ready.yaml
@@ -5,13 +5,13 @@ metadata:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
     sme.sap.com/resource-hash: bcec92268a567aadc243d28dda4ad857a41a858964b920c77f6376849e660419
-  generateName: default-test-cap-01-primary-
+  generateName: test-cap-01-primary-
   labels:
     sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/subdomain-hash: df58248c414f342c81e056b40bee12d17a08bf61
-  name: default-test-cap-01-primary-gen
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1

--- a/internal/controller/testdata/domain/primary-gateway.yaml
+++ b/internal/controller/testdata/domain/primary-gateway.yaml
@@ -3,11 +3,11 @@ kind: Gateway
 metadata:
   annotations:
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: 88fee3ef7f6c6ad863d66d5932953b7303e4494574ad594a40cfd0894834e34d
+    sme.sap.com/resource-hash: 867335af5f55d7a37c7309833ce135deb875531b2db7efbcd9b831debd1190e0
   labels:
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
-  name: default-test-cap-01-primary
+  name: test-cap-01-primary-gen
   namespace: default
   ownerReferences:
   - apiVersion: sme.sap.com/v1alpha1
@@ -27,5 +27,5 @@ spec:
       number: 443
       protocol: HTTPS
     tls:
-      credentialName: default-test-cap-01-primary
+      credentialName: default--test-cap-01-primary
       mode: SIMPLE

--- a/pkg/apis/sme.sap.com/v1alpha1/types.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/types.go
@@ -750,6 +750,8 @@ type DomainStatus struct {
 	State DomainState `json:"state"`
 	// Effective DNS Target identified for this domain
 	DnsTarget string `json:"dnsTarget,omitempty"`
+	// Gateway name used for the domain
+	GatewayName string `json:"gatewayName,omitempty"`
 	// domain observed during last reconciliation
 	ObservedDomain string `json:"observedDomain,omitempty"`
 }

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/domainstatus.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/domainstatus.go
@@ -18,6 +18,7 @@ type DomainStatusApplyConfiguration struct {
 	GenericStatusApplyConfiguration `json:",inline"`
 	State                           *smesapcomv1alpha1.DomainState `json:"state,omitempty"`
 	DnsTarget                       *string                        `json:"dnsTarget,omitempty"`
+	GatewayName                     *string                        `json:"gatewayName,omitempty"`
 	ObservedDomain                  *string                        `json:"observedDomain,omitempty"`
 }
 
@@ -61,6 +62,14 @@ func (b *DomainStatusApplyConfiguration) WithState(value smesapcomv1alpha1.Domai
 // If called multiple times, the DnsTarget field is set to the value of the last call.
 func (b *DomainStatusApplyConfiguration) WithDnsTarget(value string) *DomainStatusApplyConfiguration {
 	b.DnsTarget = &value
+	return b
+}
+
+// WithGatewayName sets the GatewayName field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the GatewayName field is set to the value of the last call.
+func (b *DomainStatusApplyConfiguration) WithGatewayName(value string) *DomainStatusApplyConfiguration {
+	b.GatewayName = &value
 	return b
 }
 


### PR DESCRIPTION
We use GenerateName wherever possible for domain (n/w) related resources
and also look these up via selectors (List) and not name (Get).

Certificates:
- Gardener certificates are now created with a GenerateName in the app
  / operator namespace, as it supports creating TLS secrets in istio
  ingress namespace.
- CertManager certificates need to be in the istio ingress namespace and
  hence use a pre-determines unique name both for certificate itself
  and the assiciated TLS secret.