### PR TITLE
[Misc] mutation web-hook: subdomain dns mode used

### DIFF
--- a/cmd/web-hooks/internal/handler/mutate.go
+++ b/cmd/web-hooks/internal/handler/mutate.go
@@ -279,7 +279,7 @@ func (wh *WebhookHandler) createClusterDomain(domain string, name string, annota
 			Domain:          domain,
 			IngressSelector: ingressSelector,
 			TLSMode:         v1alpha1.TlsModeSimple,
-			DNSMode:         v1alpha1.DnsModeWildcard,
+			DNSMode:         v1alpha1.DnsModeSubdomain,
 		},
 	}
 	// Create the Domain in the Kubernetes cluster


### PR DESCRIPTION
Use subdomain DNS mode by default for ClusterDomains