### PR TITLE
[FEAT]: CAPTenant: Additional tenant info added

### DIFF
--- a/cmd/server/internal/handler_test.go
+++ b/cmd/server/internal/handler_test.go
@@ -38,12 +38,13 @@ type httpTestClientGenerator struct {
 func (facade *httpTestClientGenerator) NewHTTPClient() *http.Client { return facade.client }
 
 const (
-	cavName         = "cav-test-controller"
-	caName          = "ca-test-controller"
-	appName         = "some-app-name"
-	globalAccountId = "cap-app-global"
-	subDomain       = "foo"
-	tenantId        = "012012012-1234-1234-123456"
+	cavName          = "cav-test-controller"
+	caName           = "ca-test-controller"
+	appName          = "some-app-name"
+	globalAccountId  = "cap-app-global"
+	subDomain        = "foo"
+	tenantId         = "012012012-1234-1234-123456"
+	subscriptionGUID = "012301234-2345-6789-ABCDEF"
 )
 
 func setup(client *http.Client, objects ...runtime.Object) *SubscriptionHandler {
@@ -297,7 +298,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request without CROs",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusNotAcceptable,
 			expectedResponse: Result{
 				Message: "the server could not find the requested resource (get capapplications.sme.sap.com)", //TODO
@@ -306,7 +307,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request with CROs with invalid app name",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"test-app","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"test-app","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			expectedStatusCode: http.StatusNotAcceptable,
 			expectedResponse: Result{
@@ -316,7 +317,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request valid (without domains)",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			expectedStatusCode: http.StatusAccepted,
 			expectedResponse: Result{
@@ -326,7 +327,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request valid (invalid domain)",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			invalidDomain:      true,
 			expectedStatusCode: http.StatusAccepted,
@@ -337,7 +338,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:                 "Provisioning Request valid (invalid clusterdomains)",
 			method:               http.MethodPut,
-			body:                 `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:                 `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:           true,
 			invalidClusterDomain: true,
 			expectedStatusCode:   http.StatusAccepted,
@@ -348,7 +349,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request valid (with domain)",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			existingDomain:     true,
 			expectedStatusCode: http.StatusAccepted,
@@ -359,7 +360,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:                  "Provisioning Request valid (with Cluster domain)",
 			method:                http.MethodPut,
-			body:                  `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:                  `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:            true,
 			existingClusterDomain: true,
 			expectedStatusCode:    http.StatusAccepted,
@@ -370,7 +371,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request valid with additional data and existing tenant",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			withAdditionalData: true,
 			existingTenant:     true,
@@ -382,7 +383,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:                 "Provisioning Request valid with additional data and existing tenant and existing tenant output",
 			method:               http.MethodPut,
-			body:                 `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:                 `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:           true,
 			withAdditionalData:   true,
 			existingTenant:       true,
@@ -395,7 +396,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:                  "Provisioning Request valid with invalid additional data and existing tenant",
 			method:                http.MethodPut,
-			body:                  `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:                  `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:            true,
 			withAdditionalData:    true,
 			invalidAdditionalData: true,
@@ -408,7 +409,7 @@ func Test_provisioning(t *testing.T) {
 		{
 			name:               "Provisioning Request with existing tenant",
 			method:             http.MethodPut,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			createCROs:         true,
 			existingTenant:     true,
 			expectedStatusCode: http.StatusAccepted,
@@ -514,7 +515,7 @@ func Test_deprovisioning(t *testing.T) {
 			name:   "Deprovisioning Request w/o CROs",
 			method: http.MethodDelete,
 
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusNotAcceptable,
 			expectedResponse: Result{
 				Message: "the server could not find the requested resource (get capapplications.sme.sap.com)", //TODO
@@ -524,7 +525,7 @@ func Test_deprovisioning(t *testing.T) {
 			name:               "Deprovisioning Request valid",
 			method:             http.MethodDelete,
 			createCROs:         true,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusAccepted,
 			expectedResponse: Result{
 				Message: ResourceDeleted,
@@ -535,7 +536,7 @@ func Test_deprovisioning(t *testing.T) {
 			method:             http.MethodDelete,
 			createCROs:         true,
 			existingTenant:     true,
-			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscribedSubdomain":"` + subDomain + `"}`,
+			body:               `{"subscriptionAppName":"` + appName + `","globalAccountGUID":"` + globalAccountId + `","subscribedTenantId":"` + tenantId + `","subscriptionGUID":"` + subscriptionGUID + `","subscribedSubdomain":"` + subDomain + `"}`,
 			expectedStatusCode: http.StatusAccepted,
 			expectedResponse: Result{
 				Message: ResourceDeleted,

--- a/internal/controller/reconcile-capapplication.go
+++ b/internal/controller/reconcile-capapplication.go
@@ -375,7 +375,7 @@ func (c *Controller) reconcileCAPApplicationProviderTenant(ctx context.Context, 
 	if ca.IsServicesOnly() {
 		return false, nil
 	}
-	providerTenantName := strings.Join([]string{ca.Name, ProviderTenantType}, "-")
+	providerTenantName := strings.Join([]string{ca.Name, TenantTypeProvider}, "-")
 	tenant, err := c.crdInformerFactory.Sme().V1alpha1().CAPTenants().Lister().CAPTenants(ca.Namespace).Get(providerTenantName)
 	if err != nil {
 		if !k8sErrors.IsNotFound(err) {
@@ -430,7 +430,7 @@ func (c *Controller) reconcileCAPApplicationProviderTenant(ctx context.Context, 
 					},
 					Labels: map[string]string{
 						LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName),
-						LabelTenantType:                   ProviderTenantType,
+						LabelTenantType:                   TenantTypeProvider,
 						LabelTenantId:                     ca.Spec.Provider.TenantId,
 					},
 				},

--- a/internal/controller/reconcile-captenant.go
+++ b/internal/controller/reconcile-captenant.go
@@ -617,14 +617,6 @@ func addCAPTenantLabels(cat *v1alpha1.CAPTenant, ca *v1alpha1.CAPApplication) (u
 		cat.ObjectMeta.Labels[LabelTenantId] = cat.Spec.TenantId
 		updated = true
 	}
-	if _, ok := cat.ObjectMeta.Labels[LabelTenantType]; !ok {
-		if ca.Spec.Provider.TenantId == cat.Spec.TenantId {
-			cat.ObjectMeta.Labels[LabelTenantType] = ProviderTenantType
-		} else {
-			cat.ObjectMeta.Labels[LabelTenantType] = ConsumerTenantType
-		}
-		updated = true
-	}
 	return updated
 }
 

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -74,10 +74,7 @@ var (
 	tTLSecondsAfterFinishedValue int32 = 300
 )
 
-const (
-	ProviderTenantType = "provider"
-	ConsumerTenantType = "consumer"
-)
+const TenantTypeProvider = "provider"
 
 // Use a different name for sticky cookie than the one from approuter (JSESSIONID) used for session handling
 const RouterHttpCookieName = "CAPOP_ROUTER_STICKY"

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -222,7 +222,7 @@ func createCatCRO(caName string, tenantType string, withFinalizers bool) *v1alph
 		},
 	}
 
-	if tenantType == ProviderTenantType {
+	if tenantType == TenantTypeProvider {
 		cat.Spec.BTPTenantIdentification.TenantId = providerTenantId
 		cat.Spec.BTPTenantIdentification.SubDomain = providerSubDomain
 	} else {

--- a/internal/controller/testdata/capapplication/cat-consumer-no-finalizers-ready.yaml
+++ b/internal/controller/testdata/capapplication/cat-consumer-no-finalizers-ready.yaml
@@ -4,12 +4,14 @@ metadata:
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   labels:
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/btp-tenant-id: tenant-id-for-consumer
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/capapplication/cat-consumer-upg-never-deleting.yaml
+++ b/internal/controller/testdata/capapplication/cat-consumer-upg-never-deleting.yaml
@@ -7,11 +7,13 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
     sme.sap.com/btp-tenant-id: "provider-tenant-id"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/capapplication/cat-consumer-upg-never-ready.yaml
+++ b/internal/controller/testdata/capapplication/cat-consumer-upg-never-ready.yaml
@@ -7,11 +7,13 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
     sme.sap.com/btp-tenant-id: "provider-tenant-id"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/capapplication/cat-consumer-upgrading.yaml
+++ b/internal/controller/testdata/capapplication/cat-consumer-upgrading.yaml
@@ -7,11 +7,13 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
     sme.sap.com/btp-tenant-id: "provider-tenant-id"
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/captenant/cat-01.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-01.initial.yaml
@@ -3,6 +3,8 @@ kind: CAPTenant
 metadata:
   name: test-cap-01-provider
   namespace: default
+  labels:
+    sme.sap.com/tenant-type: provider
 spec:
   capApplicationInstance: test-cap-01
   subDomain: my-provider

--- a/internal/controller/testdata/captenant/cat-02.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-02.expected.yaml
@@ -9,9 +9,11 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/captenant/cat-02.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-02.initial.yaml
@@ -3,6 +3,11 @@ kind: CAPTenant
 metadata:
   name: test-cap-01-consumer
   namespace: default
+  labels:
+    sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
+  annotations:
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
 spec:
   capApplicationInstance: test-cap-01
   subDomain: my-consumer

--- a/internal/controller/testdata/captenant/cat-03.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-03.expected.yaml
@@ -9,9 +9,11 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/captenant/cat-03.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-03.initial.yaml
@@ -9,9 +9,11 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/captenant/cat-14.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-14.initial.yaml
@@ -9,9 +9,11 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/captenant/cat-28.expected.yaml
+++ b/internal/controller/testdata/captenant/cat-28.expected.yaml
@@ -9,9 +9,11 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/captenant/cat-28.initial.yaml
+++ b/internal/controller/testdata/captenant/cat-28.initial.yaml
@@ -9,9 +9,11 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/captenant/cat-with-no-version.yaml
+++ b/internal/controller/testdata/captenant/cat-with-no-version.yaml
@@ -9,9 +9,11 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:

--- a/internal/controller/testdata/version-monitoring/cat-consumer-v2-upgrading.yaml
+++ b/internal/controller/testdata/version-monitoring/cat-consumer-v2-upgrading.yaml
@@ -9,10 +9,12 @@ metadata:
     sme.sap.com/owner-generation: "2"
     sme.sap.com/owner-identifier-hash: 1f74ae2fbff71a708786a4df4bb2ca87ec603581
     sme.sap.com/tenant-type: consumer
+    sme.sap.com/subscription-guid-hash: 4b10784b8123e511c428113ec738a8c7c822d84e
   annotations:
     sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01
     sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
+    sme.sap.com/subscription-guid: 38b55555f64b627466e54862859719df031eea0f
   name: test-cap-01-consumer
   namespace: default
   ownerReferences:


### PR DESCRIPTION
- Introduced additional tenant info via labels/annotation to hold
 tenant-specific information including subscription GUID (GlobalTenantId)
 and TenantType.
- Updated logic to set tenant type based on the tenant being processed
 (consumer/provider) during creation.
- Enhanced test cases to validate the new tenant type information in
 various scenarios.