### PR TITLE
[Fix] version-monitoring: Latest Ready CAV excluded

### DIFF
--- a/internal/controller/version-monitoring.go
+++ b/internal/controller/version-monitoring.go
@@ -212,6 +212,9 @@ func (c *Controller) getCleanupRelevantVersions(ca *v1alpha1.CAPApplication) ([]
 		return nil, err
 	}
 
+	// Explicitly exclude the latest Ready version from cleanup
+	excludedVersions[latestReadyVersion.Spec.Version] = true
+
 	outdatedVersions := []*v1alpha1.CAPApplicationVersion{}
 	cavs, _ := c.getCachedCAPApplicationVersions(ca) // ignoring error as this is not critical
 	for i := range cavs {


### PR DESCRIPTION
Always exclude the latest Ready CAV from cleanup when version monitoring is enabled.