### PR TITLE
[Feat] Operator: Job(s) - Active deadline added

### DIFF
--- a/crds/sme.sap.com_capapplicationversions.yaml
+++ b/crds/sme.sap.com_capapplicationversions.yaml
@@ -2640,6 +2640,9 @@ spec:
                       type: object
                     jobDefinition:
                       properties:
+                        activeDeadlineSeconds:
+                          format: int64
+                          type: integer
                         affinity:
                           properties:
                             nodeAffinity:

--- a/internal/controller/reconcile-capapplicationversion.go
+++ b/internal/controller/reconcile-capapplicationversion.go
@@ -335,6 +335,7 @@ func newContentDeploymentJob(cav *v1alpha1.CAPApplicationVersion, workload *v1al
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            workload.JobDefinition.BackoffLimit,
 			TTLSecondsAfterFinished: workload.JobDefinition.TTLSecondsAfterFinished,
+			ActiveDeadlineSeconds:   workload.JobDefinition.ActiveDeadlineSeconds,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: annotations,

--- a/internal/controller/reconcile-captenantoperation.go
+++ b/internal/controller/reconcile-captenantoperation.go
@@ -51,6 +51,7 @@ type tentantOperationWorkload struct {
 	tolerations               []corev1.Toleration
 	backoffLimit              *int32
 	ttlSecondsAfterFinished   *int32
+	activeDeadlineSeconds     *int64
 	restartPolicy             corev1.RestartPolicy
 }
 
@@ -479,6 +480,7 @@ func (c *Controller) createTenantOperationJob(ctx context.Context, ctop *v1alpha
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            derivedWorkload.backoffLimit,
 			TTLSecondsAfterFinished: derivedWorkload.ttlSecondsAfterFinished,
+			ActiveDeadlineSeconds:   derivedWorkload.activeDeadlineSeconds,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      params.labels,
@@ -575,6 +577,7 @@ func deriveWorkloadForTenantOperation(workload *v1alpha1.WorkloadDetails) tentan
 		if workload.JobDefinition.TTLSecondsAfterFinished != nil {
 			result.ttlSecondsAfterFinished = workload.JobDefinition.TTLSecondsAfterFinished
 		}
+		result.activeDeadlineSeconds = workload.JobDefinition.ActiveDeadlineSeconds
 		result.restartPolicy = workload.JobDefinition.RestartPolicy
 		result.affinity = workload.JobDefinition.Affinity
 		result.nodeSelector = workload.JobDefinition.NodeSelector
@@ -599,6 +602,7 @@ func (c *Controller) createCustomTenantOperationJob(ctx context.Context, ctop *v
 		Spec: batchv1.JobSpec{
 			BackoffLimit:            workload.JobDefinition.BackoffLimit,
 			TTLSecondsAfterFinished: workload.JobDefinition.TTLSecondsAfterFinished,
+			ActiveDeadlineSeconds:   workload.JobDefinition.ActiveDeadlineSeconds,
 			Template: corev1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels:      params.labels,

--- a/pkg/apis/sme.sap.com/v1alpha1/types.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/types.go
@@ -387,6 +387,8 @@ type JobDetails struct {
 	BackoffLimit *int32 `json:"backoffLimit,omitempty"`
 	// Specifies the time after which the job may be cleaned up.
 	TTLSecondsAfterFinished *int32 `json:"ttlSecondsAfterFinished,omitempty"`
+	// Specifies the duration in sections for which the job may be continuously active.
+	ActiveDeadlineSeconds *int64 `json:"activeDeadlineSeconds,omitempty"`
 }
 
 // Type of Job

--- a/pkg/apis/sme.sap.com/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/zz_generated.deepcopy.go
@@ -1041,6 +1041,11 @@ func (in *JobDetails) DeepCopyInto(out *JobDetails) {
 		*out = new(int32)
 		**out = **in
 	}
+	if in.ActiveDeadlineSeconds != nil {
+		in, out := &in.ActiveDeadlineSeconds, &out.ActiveDeadlineSeconds
+		*out = new(int64)
+		**out = **in
+	}
 	return
 }
 

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/jobdetails.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/jobdetails.go
@@ -19,6 +19,7 @@ type JobDetailsApplyConfiguration struct {
 	Type                            *smesapcomv1alpha1.JobType `json:"type,omitempty"`
 	BackoffLimit                    *int32                     `json:"backoffLimit,omitempty"`
 	TTLSecondsAfterFinished         *int32                     `json:"ttlSecondsAfterFinished,omitempty"`
+	ActiveDeadlineSeconds           *int64                     `json:"activeDeadlineSeconds,omitempty"`
 }
 
 // JobDetailsApplyConfiguration constructs a declarative configuration of the JobDetails type for use with
@@ -222,5 +223,13 @@ func (b *JobDetailsApplyConfiguration) WithBackoffLimit(value int32) *JobDetails
 // If called multiple times, the TTLSecondsAfterFinished field is set to the value of the last call.
 func (b *JobDetailsApplyConfiguration) WithTTLSecondsAfterFinished(value int32) *JobDetailsApplyConfiguration {
 	b.TTLSecondsAfterFinished = &value
+	return b
+}
+
+// WithActiveDeadlineSeconds sets the ActiveDeadlineSeconds field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the ActiveDeadlineSeconds field is set to the value of the last call.
+func (b *JobDetailsApplyConfiguration) WithActiveDeadlineSeconds(value int64) *JobDetailsApplyConfiguration {
+	b.ActiveDeadlineSeconds = &value
 	return b
 }


### PR DESCRIPTION
Allow setting ActiveDeadlineSeconds in Job spec.
This let's consumers provide a way to exit long running / misconfigured jobs.