### PR TITLE
[FEAT] Operator: AppId handling enhanced

### DIFF
--- a/cmd/controller/main.go
+++ b/cmd/controller/main.go
@@ -126,10 +126,15 @@ func main() {
 
 				c := controller.NewController(coreClient, crdClient, istioClient, certClient, certManagerClient, dnsClient, promClient)
 
-				checkDone := make(chan bool, 1)
-				go checkDRs(checkDone, istioClient, crdClient)
-				<-checkDone
+				checkDR := make(chan bool, 1)
+				go checkDRs(checkDR, istioClient, crdClient)
+				<-checkDR
 				klog.InfoS("check & update of DestinationRules done")
+
+				migrateApp := make(chan bool, 1)
+				go migrateApps(migrateApp, crdClient)
+				<-migrateApp
+				klog.InfoS("migration of app Id done")
 
 				// Update the controller's concurrency config before starting the controller
 				maps.Copy(controller.DefaultConcurrentReconciles, concurrencyConfig)

--- a/cmd/controller/tmp.go
+++ b/cmd/controller/tmp.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/sap/cap-operator/internal/controller"
 	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
 	"github.com/sap/cap-operator/pkg/client/clientset/versioned"
 	"google.golang.org/protobuf/types/known/durationpb"
@@ -24,10 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"k8s.io/klog/v2"
-)
-
-const (
-	LabelOwnerIdentifierHash = "sme.sap.com/owner-identifier-hash"
 )
 
 func checkDRs(checkDone chan bool, istioClient istio.Interface, crdClient versioned.Interface) {
@@ -93,7 +90,7 @@ func checkDRs(checkDone chan bool, istioClient istio.Interface, crdClient versio
 	// Delete all DestinationRules in the tenant's namespace that have the relevant ownerId label
 	for _, tenant := range tenants.Items {
 		ownerIdentifierHash := sha1Sum(tenant.Namespace, tenant.Name)
-		ownerLabelHashReq, _ := labels.NewRequirement(LabelOwnerIdentifierHash, selection.Equals, []string{ownerIdentifierHash})
+		ownerLabelHashReq, _ := labels.NewRequirement(controller.LabelOwnerIdentifierHash, selection.Equals, []string{ownerIdentifierHash})
 		ownerLabelHashReqSelector := labels.NewSelector().Add(*ownerLabelHashReq)
 		err := istioClient.NetworkingV1().DestinationRules(tenant.Namespace).DeleteCollection(context.TODO(), metav1.DeleteOptions{}, metav1.ListOptions{
 			LabelSelector: ownerLabelHashReqSelector.String(),
@@ -119,4 +116,123 @@ func getDRName(cav v1alpha1.CAPApplicationVersion) string {
 func sha1Sum(source ...string) string {
 	sum := sha1.Sum([]byte(strings.Join(source, "")))
 	return fmt.Sprintf("%x", sum)
+}
+
+// migrateAppIdLabels replaces the deprecated BTP app identifier label/annotation with
+// the new app identifier label/annotation on the given ObjectMeta.
+func migrateAppIdLabels(object *metav1.ObjectMeta, appIdHash, appId string) {
+	if object.Labels == nil {
+		object.Labels = map[string]string{}
+	}
+	if object.Annotations == nil {
+		object.Annotations = map[string]string{}
+	}
+	object.Labels[controller.LabelAppIdHash] = appIdHash
+	delete(object.Labels, controller.LabelBTPApplicationIdentifierHash)
+	object.Annotations[controller.AnnotationAppId] = appId
+	delete(object.Annotations, controller.AnnotationBTPApplicationIdentifier)
+}
+
+func btpAppIdHashSelector(ca v1alpha1.CAPApplication) string {
+	return labels.SelectorFromSet(map[string]string{
+		controller.LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName),
+	}).String()
+}
+
+func migrateCAPApplicationVersions(crdClient versioned.Interface, ca v1alpha1.CAPApplication, appIdHash, appId string) {
+	cavs, err := crdClient.SmeV1alpha1().CAPApplicationVersions(ca.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: btpAppIdHashSelector(ca),
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to list CAPApplicationVersions", "capApplication", ca.Name, "namespace", ca.Namespace)
+		return
+	}
+	for _, cav := range cavs.Items {
+		cavCopy := cav.DeepCopy()
+		migrateAppIdLabels(&cavCopy.ObjectMeta, appIdHash, appId)
+		if _, err := crdClient.SmeV1alpha1().CAPApplicationVersions(cav.Namespace).Update(context.TODO(), cavCopy, metav1.UpdateOptions{}); err != nil {
+			klog.ErrorS(err, "Failed to update CAPApplicationVersion", "name", cav.Name, "namespace", cav.Namespace)
+		}
+	}
+}
+
+func migrateCAPTenants(crdClient versioned.Interface, ca v1alpha1.CAPApplication, appIdHash, appId string) {
+	cats, err := crdClient.SmeV1alpha1().CAPTenants(ca.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: btpAppIdHashSelector(ca),
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to list CAPTenants", "capApplication", ca.Name, "namespace", ca.Namespace)
+		return
+	}
+	for _, cat := range cats.Items {
+		catCopy := cat.DeepCopy()
+		migrateAppIdLabels(&catCopy.ObjectMeta, appIdHash, appId)
+		if _, err := crdClient.SmeV1alpha1().CAPTenants(cat.Namespace).Update(context.TODO(), catCopy, metav1.UpdateOptions{}); err != nil {
+			klog.ErrorS(err, "Failed to update CAPTenant", "name", cat.Name, "namespace", cat.Namespace)
+		}
+	}
+}
+
+func migrateCAPTenantOperations(crdClient versioned.Interface, ca v1alpha1.CAPApplication, appIdHash, appId string) {
+	ctops, err := crdClient.SmeV1alpha1().CAPTenantOperations(ca.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: btpAppIdHashSelector(ca),
+	})
+	if err != nil {
+		klog.ErrorS(err, "Failed to list CAPTenants", "capApplication", ca.Name, "namespace", ca.Namespace)
+		return
+	}
+	for _, ctop := range ctops.Items {
+		ctopCopy := ctop.DeepCopy()
+		migrateAppIdLabels(&ctopCopy.ObjectMeta, appIdHash, appId)
+		if _, err := crdClient.SmeV1alpha1().CAPTenantOperations(ctop.Namespace).Update(context.TODO(), ctopCopy, metav1.UpdateOptions{}); err != nil {
+			klog.ErrorS(err, "Failed to update CAPTenant", "name", ctop.Name, "namespace", ctop.Namespace)
+		}
+	}
+}
+
+func needsMigration(ca *v1alpha1.CAPApplication, appIdHash string) bool {
+	if ca.Labels[controller.LabelAppIdHash] != appIdHash {
+		return true
+	}
+	if _, ok := ca.Labels[controller.LabelBTPApplicationIdentifierHash]; ok {
+		return true
+	}
+	return false
+}
+
+func migrateApps(migrationDone chan bool, crdClient versioned.Interface) {
+	// Always set the channel to true in the end
+	defer func() {
+		migrationDone <- true
+	}()
+
+	// Go over all CAP applications and check if spec has ProviderSubaccountId set, if so trigger update after setting LabelAppIdHash and AnnotationAppId and remove LabelBTPApplicationIdentifierHash & AnnotationBTPApplicationIdentifier from all CAs.
+	apps, err := crdClient.SmeV1alpha1().CAPApplications(metav1.NamespaceAll).List(context.TODO(), metav1.ListOptions{})
+	if err != nil {
+		klog.ErrorS(err, "Failed to list CAP applications")
+		return
+	}
+
+	for _, ca := range apps.Items {
+		if ca.Spec.ProviderSubaccountId == "" {
+			continue
+		}
+
+		appIdHash := sha1Sum(ca.Spec.ProviderSubaccountId, ca.Spec.BTPAppName)
+		appId := strings.Join([]string{ca.Spec.ProviderSubaccountId, ca.Spec.BTPAppName}, ".")
+
+		// Update the CAPApplication itself if the new label is not yet set
+		if needsMigration(&ca, appIdHash) {
+			caCopy := ca.DeepCopy()
+			migrateAppIdLabels(&caCopy.ObjectMeta, appIdHash, appId)
+			if _, err := crdClient.SmeV1alpha1().CAPApplications(ca.Namespace).Update(context.TODO(), caCopy, metav1.UpdateOptions{}); err != nil {
+				klog.ErrorS(err, "Failed to update CAPApplication", "name", ca.Name, "namespace", ca.Namespace)
+				continue
+			}
+		}
+
+		migrateCAPApplicationVersions(crdClient, ca, appIdHash, appId)
+		migrateCAPTenants(crdClient, ca, appIdHash, appId)
+		migrateCAPTenantOperations(crdClient, ca, appIdHash, appId)
+	}
 }

--- a/cmd/server/internal/handler.go
+++ b/cmd/server/internal/handler.go
@@ -183,7 +183,7 @@ func (s *SubscriptionHandler) CreateTenant(reqInfo *RequestInfo) *Result {
 	}
 
 	// Check if A CRO for CAPTenant already exists
-	tenant := s.getTenantByBtpAppIdentifier(ca.Spec.GlobalAccountId, reqInfo.payload.appName, reqInfo.payload.tenantId, ca.Namespace, TenantProvisioning).Tenant
+	tenant := s.getTenantByAppIdentifier(ca.Spec.GlobalAccountId, ca.Spec.ProviderSubaccountId, reqInfo.payload.appName, reqInfo.payload.tenantId, ca.Namespace, TenantProvisioning).Tenant
 
 	// If the resource doesn't exist, we'll create it
 	if tenant == nil {
@@ -235,9 +235,8 @@ func (s *SubscriptionHandler) createTenant(reqInfo *RequestInfo, ca *v1alpha1.CA
 			GenerateName: ca.Name + "-consumer-",
 			Namespace:    ca.Namespace,
 			Labels: map[string]string{
-				LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, reqInfo.payload.appName),
-				LabelTenantId:                     reqInfo.payload.tenantId,
-				LabelSubscriptionGUID:             subscriptionGUID,
+				LabelTenantId:         reqInfo.payload.tenantId,
+				LabelSubscriptionGUID: subscriptionGUID,
 			},
 		},
 		StringData: map[string]string{
@@ -259,10 +258,9 @@ func (s *SubscriptionHandler) createTenant(reqInfo *RequestInfo, ca *v1alpha1.CA
 				AnnotationSubscriptionContextSecret: secret.Name, // Store the secret name in the tenant annotation
 			},
 			Labels: map[string]string{
-				LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, reqInfo.payload.appName),
-				LabelTenantId:                     reqInfo.payload.tenantId,
-				LabelSubscriptionGUID:             subscriptionGUID,
-				LabelTenantType:                   "consumer", // Default tenant type for consumer tenants
+				LabelTenantId:         reqInfo.payload.tenantId,
+				LabelSubscriptionGUID: subscriptionGUID,
+				LabelTenantType:       "consumer", // Default tenant type for consumer tenants
 			},
 		},
 		Spec: v1alpha1.CAPTenantSpec{
@@ -408,12 +406,20 @@ func (s *SubscriptionHandler) updateSecret(tenant *v1alpha1.CAPTenant, secret *c
 	return err
 }
 
-func (s *SubscriptionHandler) getTenantByBtpAppIdentifier(globalAccountGUID, btpAppName, tenantId, namespace, step string) *Result {
-	labelsMap := map[string]string{
-		LabelBTPApplicationIdentifierHash: sha1Sum(globalAccountGUID, btpAppName),
-		LabelTenantId:                     tenantId,
+func (s *SubscriptionHandler) getTenantByAppIdentifier(globalAccountGUID, providerSubAccountId, btpAppName, tenantId, namespace, step string) (result *Result) {
+	tenantlabels := map[string]string{
+		LabelTenantId: tenantId,
 	}
-	return s.getTenantByLabels(labelsMap, namespace, step, "getTenantByBtpAppIdentifier")
+
+	labelsMaps := maps.Clone(tenantlabels)
+	labelsMaps[LabelAppIdHash] = sha1Sum(providerSubAccountId, btpAppName)
+
+	if result = s.getTenantByLabels(labelsMaps, namespace, step, "getTenantByAppIdentifier"); result.Tenant == nil {
+		oldLabelsMap := maps.Clone(tenantlabels)
+		oldLabelsMap[LabelBTPApplicationIdentifierHash] = sha1Sum(globalAccountGUID, btpAppName)
+		result = s.getTenantByLabels(oldLabelsMap, namespace, step, "getTenantByAppIdentifier")
+	}
+	return
 }
 
 func (s *SubscriptionHandler) getTenantBySubscriptionGUID(subscriptionGUID, tenantId, step string) *Result {
@@ -481,7 +487,7 @@ func (s *SubscriptionHandler) DeleteTenant(reqInfo *RequestInfo) *Result {
 		}
 		// if tenant is not found in SaaS subscription scenario, check if it exists by btpApp identifier to handle cases where tenant was created without subscriptionGUID
 		util.LogInfo("Tenant not found by subscriptionGUID, checking by BTP app identifier", TenantDeprovisioning, "DeleteTenant", nil, "subscriptionGUID", reqInfo.payload.subscriptionGUID)
-		tenant = s.getTenantByBtpAppIdentifier(ca.Spec.GlobalAccountId, reqInfo.payload.appName, reqInfo.payload.tenantId, metav1.NamespaceAll, TenantDeprovisioning).Tenant
+		tenant = s.getTenantByAppIdentifier(ca.Spec.GlobalAccountId, ca.Spec.ProviderSubaccountId, reqInfo.payload.appName, reqInfo.payload.tenantId, metav1.NamespaceAll, TenantDeprovisioning).Tenant
 	}
 
 	if tenant == nil {

--- a/cmd/server/internal/handler_test.go
+++ b/cmd/server/internal/handler_test.go
@@ -152,9 +152,8 @@ func createTenantSubscriptionContextSecret(subscriptionContext string) runtime.O
 			Name:      subscriptionContextSecretName,
 			Namespace: v1.NamespaceDefault,
 			Labels: map[string]string{
-				LabelBTPApplicationIdentifierHash: sha1Sum(globalAccountId, appName),
-				LabelTenantId:                     tenantId,
-				LabelSubscriptionGUID:             subscriptionGUID,
+				LabelTenantId:         tenantId,
+				LabelSubscriptionGUID: subscriptionGUID,
 			},
 		},
 		StringData: map[string]string{

--- a/crds/sme.sap.com_capapplications.yaml
+++ b/crds/sme.sap.com_capapplications.yaml
@@ -117,8 +117,12 @@ spec:
             required:
             - btp
             - btpAppName
-            - globalAccountId
             type: object
+            x-kubernetes-validations:
+            - message: at least one of the fields in [globalAccountId providerSubaccountId]
+                must be set
+              rule: '[has(self.globalAccountId),has(self.providerSubaccountId)].filter(x,x==true).size()
+                >= 1'
           status:
             properties:
               conditions:

--- a/internal/controller/dns-manager.go
+++ b/internal/controller/dns-manager.go
@@ -90,10 +90,9 @@ func handleDnsEntries[T v1alpha1.DomainEntity](ctx context.Context, c *Controlle
 				GenerateName: subResourceName + "-",
 				Namespace:    subResourceNamespace,
 				Labels: map[string]string{
-					LabelOwnerIdentifierHash:          sha1Sum(ownerId),
-					LabelOwnerGeneration:              fmt.Sprintf("%d", dom.GetMetadata().Generation),
-					LabelBTPApplicationIdentifierHash: info.appId,
-					LabelDNSNameHash:                  dnsHash,
+					LabelOwnerIdentifierHash: sha1Sum(ownerId),
+					LabelOwnerGeneration:     fmt.Sprintf("%d", dom.GetMetadata().Generation),
+					LabelDNSNameHash:         dnsHash,
 				},
 				Annotations: map[string]string{
 					AnnotationResourceHash:     hash,
@@ -132,7 +131,6 @@ func checkRelevantDNSEntries(ctx context.Context, dnsEntries []dnsv1alpha1.DNSEn
 			if entry.Annotations[AnnotationResourceHash] != hash {
 				updateResourceAnnotation(&entry.ObjectMeta, hash)
 				entry.Labels[LabelOwnerGeneration] = fmt.Sprintf("%d", generation)
-				entry.Labels[LabelBTPApplicationIdentifierHash] = info.appId
 				entry.Labels[LabelDNSNameHash] = dnsHash
 				entry.Spec = getDnsEntrySpec(info)
 				_, err = c.gardenerDNSClient.DnsV1alpha1().DNSEntries(entry.Namespace).Update(ctx, &entry, metav1.UpdateOptions{})
@@ -275,8 +273,8 @@ func collectAppSubdomainInfos[T v1alpha1.DomainEntity](c *Controller, dom T) (su
 		if len(ca.Status.ObservedSubdomains) > 0 {
 			for _, subdomain := range ca.Status.ObservedSubdomains {
 				if appId, ok := subdomains[subdomain]; !ok {
-					subdomains[subdomain] = ca.Labels[LabelBTPApplicationIdentifierHash]
-				} else if appId != ca.Labels[LabelBTPApplicationIdentifierHash] {
+					subdomains[subdomain] = string(ca.UID)
+				} else if appId != string(ca.UID) {
 					// this subdomain is already used by another application
 					// skip and raise warning event
 					c.Event(ca, runtime.Object(dom), corev1.EventTypeWarning, DomainEventSubdomainAlreadyInUse, EventActionProcessingDomainResources,

--- a/internal/controller/reconcile-capapplication.go
+++ b/internal/controller/reconcile-capapplication.go
@@ -380,8 +380,11 @@ func (c *Controller) getRelevantTenantsForCA(ca *v1alpha1.CAPApplication) ([]*v1
 	if ca.IsServicesOnly() {
 		return []*v1alpha1.CAPTenant{}, nil
 	}
-	tenantLabels := map[string]string{
-		LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName),
+	tenantLabels := map[string]string{}
+	if ca.Spec.ProviderSubaccountId != "" {
+		tenantLabels[LabelAppIdHash] = sha1Sum(ca.Spec.ProviderSubaccountId, ca.Spec.BTPAppName)
+	} else {
+		tenantLabels[LabelBTPApplicationIdentifierHash] = sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName)
 	}
 	selector, err := labels.ValidatedSelectorFromSet(tenantLabels)
 	if err != nil {
@@ -426,27 +429,33 @@ func (c *Controller) reconcileCAPApplicationProviderTenant(ctx context.Context, 
 }
 
 func (c *Controller) createProviderTenant(ctx context.Context, ca *v1alpha1.CAPApplication, version string, providerTenantName string) (tenant *v1alpha1.CAPTenant, err error) {
-	// Create a secret with the provider subscription context (dervied from the spec of CAPApplication)
-	// Try to get the provider subaccount id from the annotations
-	providerSubAccountId := ca.Annotations[AnnotationProviderSubAccountId]
-	// If no provider subaccount id annotation is found use provider tenantId that is needed because some cds / hana APIs seem to rely on this field instead of tenantId!
-	if providerSubAccountId == "" {
-		providerSubAccountId = ca.Spec.Provider.TenantId
+	providerSubaccountId := ""
+	tenantLabels := map[string]string{
+		LabelTenantId: ca.Spec.Provider.TenantId,
 	}
+	// Create a secret with the provider subscription context (dervied from the spec of CAPApplication)
+	if ca.Spec.ProviderSubaccountId != "" {
+		providerSubaccountId = ca.Spec.ProviderSubaccountId
+	} else {
+		// Try to get the provider subaccount id from the annotations
+		providerSubaccountId = ca.Annotations[AnnotationProviderSubAccountId]
+		// If no provider subaccount id annotation is found use provider tenantId that is needed because some cds / hana APIs seem to rely on this field instead of tenantId!
+		if providerSubaccountId == "" {
+			providerSubaccountId = ca.Spec.Provider.TenantId
+		}
+	}
+
 	secret, err := c.kubeClient.CoreV1().Secrets(ca.Namespace).Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: providerTenantName + "-",
 			Namespace:    ca.Namespace,
-			Labels: map[string]string{
-				LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName),
-				LabelTenantId:                     ca.Spec.Provider.TenantId,
-			},
+			Labels:       tenantLabels,
 		},
 		StringData: map[string]string{
 			SubscriptionContext: `{
 					"subscriptionAppName": "` + ca.Spec.BTPAppName + `",
 					"subscribedTenantId": "` + ca.Spec.Provider.TenantId + `",
-					"subscribedSubaccountId": "` + providerSubAccountId + `",
+					"subscribedSubaccountId": "` + providerSubaccountId + `",
 					"subscribedSubdomain": "` + ca.Spec.Provider.SubDomain + `",
 					"globalAccountGUID": "` + ca.Spec.GlobalAccountId + `"
 				}`,
@@ -460,22 +469,26 @@ func (c *Controller) createProviderTenant(ctx context.Context, ca *v1alpha1.CAPA
 
 	// Create provider tenant
 	util.LogInfo("Creating provider tenant", string(Processing), ca, nil, "tenantId", ca.Spec.Provider.TenantId)
+	annotations := map[string]string{
+		AnnotationSubscriptionContextSecret: secret.Name, // Store the secret name in the tenant annotation
+	}
+	labels := map[string]string{
+		LabelTenantType: TenantTypeProvider,
+		LabelTenantId:   ca.Spec.Provider.TenantId,
+	}
+	if ca.Spec.ProviderSubaccountId != "" {
+		labels[LabelAppIdHash] = sha1Sum(ca.Spec.ProviderSubaccountId, ca.Spec.BTPAppName)
+	} else {
+		labels[LabelBTPApplicationIdentifierHash] = sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName)
+	}
 
 	if tenant, err = c.crdClient.SmeV1alpha1().CAPTenants(ca.Namespace).Create(
 		ctx, &v1alpha1.CAPTenant{
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      providerTenantName,
-				Namespace: ca.Namespace,
-				Annotations: map[string]string{
-					AnnotationBTPApplicationIdentifier:  ca.Spec.GlobalAccountId + "." + ca.Spec.BTPAppName,
-					AnnotationSubscriptionContextSecret: secret.Name, // Store the secret name in the tenant annotation
-
-				},
-				Labels: map[string]string{
-					LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName),
-					LabelTenantType:                   TenantTypeProvider,
-					LabelTenantId:                     ca.Spec.Provider.TenantId,
-				},
+				Name:        providerTenantName,
+				Namespace:   ca.Namespace,
+				Annotations: annotations,
+				Labels:      labels,
 			},
 			Spec: v1alpha1.CAPTenantSpec{
 				CAPApplicationInstance: ca.Name,
@@ -580,8 +593,8 @@ func (c *Controller) prepareCAPApplication(ca *v1alpha1.CAPApplication) (update 
 	// add Label/Annotation for BTP App
 	appMetadata := appMetadataIdentifiers{
 		globalAccountId:      ca.Spec.GlobalAccountId,
-		appName:              ca.Spec.BTPAppName,
 		providerSubaccountId: ca.Spec.ProviderSubaccountId,
+		appName:              ca.Spec.BTPAppName,
 	}
 	if updateLabelAnnotationMetadata(&ca.ObjectMeta, &appMetadata) {
 		update = true
@@ -708,13 +721,19 @@ func (c *Controller) addApplicationResourcesToReconcileResult(ca *v1alpha1.CAPAp
 }
 
 // Collect service operation metrics based on the status of the CAV
-func collectServiceOperationMetrics(cav *v1alpha1.CAPApplicationVersion, err error) {
+func collectServiceOperationMetrics(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion, err error) {
+	appIdHash := ""
+	if ca.Spec.ProviderSubaccountId != "" {
+		appIdHash = cav.Labels[LabelAppIdHash]
+	} else {
+		appIdHash = cav.Labels[LabelBTPApplicationIdentifierHash]
+	}
 	// Collect/Increment overall completed service operation metrics
-	ServiceOperations.WithLabelValues(cav.Labels[LabelBTPApplicationIdentifierHash]).Inc()
+	ServiceOperations.WithLabelValues(appIdHash).Inc()
 
 	if err != nil {
 		// Collect/Increment failed service operation metrics with CAV details
-		ServiceOperationFailures.WithLabelValues(cav.Labels[LabelBTPApplicationIdentifierHash], cav.Spec.Version, cav.Namespace, cav.Name).Inc()
+		ServiceOperationFailures.WithLabelValues(appIdHash, cav.Spec.Version, cav.Namespace, cav.Name).Inc()
 	}
 }
 

--- a/internal/controller/reconcile-capapplicationversion.go
+++ b/internal/controller/reconcile-capapplicationversion.go
@@ -463,7 +463,7 @@ func newService(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion
 
 	workload := getWorkloadByName(workloadServicePortInfo.WorkloadName[len(cav.Name)+1:], cav)
 
-	annotations := copyMaps(workload.Annotations, getAnnotations(ca, cav, true))
+	annotations := copyMaps(workload.Annotations, getAnnotations(cav))
 
 	labels := copyMaps(workload.Labels, getLabels(ca, cav, CategoryService, workloadServicePortInfo.DeploymentType, workloadServicePortInfo.WorkloadName+ServiceSuffix, true))
 
@@ -562,7 +562,7 @@ func newServiceMonitor(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplication
 			Name:        wlPortInfos.WorkloadName + ServiceSuffix,
 			Namespace:   cav.Namespace,
 			Labels:      copyMaps(wl.Labels, getLabels(ca, cav, CategoryServiceMonitor, string(wl.DeploymentDefinition.Type), wlPortInfos.WorkloadName+ServiceSuffix, true)),
-			Annotations: copyMaps(wl.Annotations, getAnnotations(ca, cav, true)),
+			Annotations: copyMaps(wl.Annotations, getAnnotations(cav)),
 			OwnerReferences: []metav1.OwnerReference{
 				*metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind)),
 			},
@@ -790,7 +790,7 @@ func newHorizontalPodAutoscaler(deploymentName string, ca *v1alpha1.CAPApplicati
 				*metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind)),
 			},
 			Labels:      labels,
-			Annotations: copyMaps(workload.Annotations, getAnnotations(ca, cav, true)),
+			Annotations: copyMaps(workload.Annotations, getAnnotations(cav)),
 		},
 		Spec: hpaSpec,
 	}
@@ -821,7 +821,7 @@ func newPodDisruptionBudget(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplic
 				*metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind)),
 			},
 			Labels:      labels,
-			Annotations: copyMaps(workload.Annotations, getAnnotations(ca, cav, true)),
+			Annotations: copyMaps(workload.Annotations, getAnnotations(cav)),
 		},
 		Spec: newPodDisruptionBudgetSpec(workload, labels),
 	}
@@ -850,7 +850,7 @@ func newDeployment(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVers
 
 func createDeployment(params *DeploymentParameters) *appsv1.Deployment {
 	workloadName := getWorkloadName(params.CAV.Name, params.WorkloadDetails.Name)
-	annotations := copyMaps(params.WorkloadDetails.Annotations, getAnnotations(params.CA, params.CAV, true))
+	annotations := copyMaps(params.WorkloadDetails.Annotations, getAnnotations(params.CAV))
 	labels := copyMaps(params.WorkloadDetails.Labels, getLabels(params.CA, params.CAV, CategoryWorkload, string(params.WorkloadDetails.DeploymentDefinition.Type), workloadName, true))
 	if isExposedWorkload(params.WorkloadDetails, params.CAV) {
 		labels[LabelExposedWorkload] = "true"
@@ -1031,26 +1031,18 @@ func (c *Controller) prepareCAPApplicationVersion(cav *v1alpha1.CAPApplicationVe
 }
 
 // Annotations
-func getAnnotations(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion, ownerInfo bool) map[string]string {
-	annotations := map[string]string{
-		AnnotationBTPApplicationIdentifier: strings.Join([]string{ca.Spec.GlobalAccountId, ca.Spec.BTPAppName}, "."),
+func getAnnotations(cav *v1alpha1.CAPApplicationVersion) map[string]string {
+	return map[string]string{
+		AnnotationOwnerIdentifier: cav.Namespace + "." + cav.Name,
 	}
-
-	if ownerInfo {
-		annotations[AnnotationOwnerIdentifier] = cav.Namespace + "." + cav.Name
-
-	}
-
-	return annotations
 }
 
 // Labels
 func getLabels(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion, category string, workloadType string, workloadName string, additionalDetails bool) map[string]string {
 	labels := map[string]string{
-		App:                               ca.Spec.BTPAppName,
-		LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName),
-		LabelCAVVersion:                   cav.Spec.Version,
-		LabelResourceCategory:             category,
+		App:                   ca.Spec.BTPAppName,
+		LabelCAVVersion:       cav.Spec.Version,
+		LabelResourceCategory: category,
 	}
 
 	addIfNotEmpty := func(k, v string) {
@@ -1071,8 +1063,9 @@ func getLabels(ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion,
 
 func addCAPApplicationVersionLabels(cav *v1alpha1.CAPApplicationVersion, ca *v1alpha1.CAPApplication) (updated bool) {
 	appMetadata := appMetadataIdentifiers{
-		globalAccountId: ca.Spec.GlobalAccountId,
-		appName:         ca.Spec.BTPAppName,
+		globalAccountId:      ca.Spec.GlobalAccountId,
+		providerSubaccountId: ca.Spec.ProviderSubaccountId,
+		appName:              ca.Spec.BTPAppName,
 		ownerInfo: &ownerInfo{
 			ownerNamespace:  ca.Namespace,
 			ownerName:       ca.Name,
@@ -1243,8 +1236,14 @@ func (c *Controller) getRelevantTenantsForCAV(cav *v1alpha1.CAPApplicationVersio
 	// Get CAPApplication instance
 	ca, _ := c.getCachedCAPApplication(cav.Namespace, cav.Spec.CAPApplicationInstance)
 	if ca != nil {
+		tenantLabels := map[string]string{}
+		if ca.Spec.ProviderSubaccountId != "" {
+			tenantLabels[LabelAppIdHash] = sha1Sum(ca.Spec.ProviderSubaccountId, ca.Spec.BTPAppName)
+		} else {
+			tenantLabels[LabelBTPApplicationIdentifierHash] = sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName)
+		}
 		// Get all tenants in the namespace for the CAPApplication
-		allTenants, _ := c.crdInformerFactory.Sme().V1alpha1().CAPTenants().Lister().CAPTenants(cav.Namespace).List(labels.SelectorFromSet(map[string]string{LabelBTPApplicationIdentifierHash: sha1Sum(ca.Spec.GlobalAccountId, ca.Spec.BTPAppName)}))
+		allTenants, _ := c.crdInformerFactory.Sme().V1alpha1().CAPTenants().Lister().CAPTenants(cav.Namespace).List(labels.SelectorFromSet(tenantLabels))
 		// Filter out relevant tenants for the CAPApplicationVersion
 		for _, tenant := range allTenants {
 			// If a tenant is already on a given version -or- is being provisioned/upgraded to a version, it is relevant for this CAPApplicationVersion

--- a/internal/controller/reconcile-captenant.go
+++ b/internal/controller/reconcile-captenant.go
@@ -606,8 +606,9 @@ func (c *Controller) getCAPApplicationVersionForTenantOperationType(ctx context.
 
 func addCAPTenantLabels(cat *v1alpha1.CAPTenant, ca *v1alpha1.CAPApplication) (updated bool) {
 	appMetadata := appMetadataIdentifiers{
-		globalAccountId: ca.Spec.GlobalAccountId,
-		appName:         ca.Spec.BTPAppName,
+		globalAccountId:      ca.Spec.GlobalAccountId,
+		providerSubaccountId: ca.Spec.ProviderSubaccountId,
+		appName:              ca.Spec.BTPAppName,
 		ownerInfo: &ownerInfo{
 			ownerNamespace:  ca.Namespace,
 			ownerName:       ca.Name,

--- a/internal/controller/reconcile-captenantoperation.go
+++ b/internal/controller/reconcile-captenantoperation.go
@@ -408,20 +408,18 @@ func (c *Controller) initiateJobForCAPTenantOperationStep(ctx context.Context, c
 	}
 
 	annotations := copyMaps(workload.Annotations, map[string]string{
-		AnnotationBTPApplicationIdentifier: relatedResources.CAPApplication.Spec.GlobalAccountId + "." + relatedResources.CAPApplication.Spec.BTPAppName,
-		AnnotationOwnerIdentifier:          ctop.Namespace + "." + ctop.Name,
+		AnnotationOwnerIdentifier: ctop.Namespace + "." + ctop.Name,
 	})
 
 	labels := copyMaps(workload.Labels, map[string]string{
-		App:                               relatedResources.CAPApplication.Spec.BTPAppName,
-		LabelBTPApplicationIdentifierHash: sha1Sum(relatedResources.CAPApplication.Spec.GlobalAccountId, relatedResources.CAPApplication.Spec.BTPAppName),
-		LabelOwnerIdentifierHash:          sha1Sum(ctop.Namespace, ctop.Name),
-		LabelOwnerGeneration:              strconv.FormatInt(ctop.Generation, 10),
-		LabelTenantOperationType:          string(ctop.Spec.Operation),
-		LabelTenantOperationStep:          strconv.FormatInt(int64(*ctop.Status.CurrentStep), 10), // NOTE: step is required to read the job
-		LabelWorkloadName:                 step.Name,
-		LabelWorkloadType:                 string(step.Type), // NOTE: use step type and not workload type as TenantOperation could be derived from CAP
-		LabelResourceCategory:             CategoryWorkload,
+		App:                      relatedResources.CAPApplication.Spec.BTPAppName,
+		LabelOwnerIdentifierHash: sha1Sum(ctop.Namespace, ctop.Name),
+		LabelOwnerGeneration:     strconv.FormatInt(ctop.Generation, 10),
+		LabelTenantOperationType: string(ctop.Spec.Operation),
+		LabelTenantOperationStep: strconv.FormatInt(int64(*ctop.Status.CurrentStep), 10), // NOTE: step is required to read the job
+		LabelWorkloadName:        step.Name,
+		LabelWorkloadType:        string(step.Type), // NOTE: use step type and not workload type as TenantOperation could be derived from CAP
+		LabelResourceCategory:    CategoryWorkload,
 	})
 
 	params := &jobCreateParams{
@@ -664,11 +662,17 @@ func addCAPTenantOperationLabels(ctop *v1alpha1.CAPTenantOperation, cat *v1alpha
 	}
 
 	// Check and add missing labels
-	if _, ok := ctop.Labels[LabelBTPApplicationIdentifierHash]; !ok {
+	if _, ok := cat.Labels[LabelAppIdHash]; ok {
+		if _, ok := ctop.Labels[LabelAppIdHash]; !ok {
+			ctop.Labels[LabelAppIdHash] = cat.Labels[LabelAppIdHash]
+			updated = true
+		}
+	} else if _, ok := ctop.Labels[LabelBTPApplicationIdentifierHash]; !ok {
 		// Add missing BTPApplicationIdentifierHash label
 		ctop.Labels[LabelBTPApplicationIdentifierHash] = cat.Labels[LabelBTPApplicationIdentifierHash]
 		updated = true
 	}
+
 	if _, ok := ctop.Labels[LabelTenantOperationType]; !ok {
 		// Add missing Tenant operation type label
 		ctop.Labels[LabelTenantOperationType] = string(ctop.Spec.Operation)
@@ -726,16 +730,23 @@ func getCTOPEnv(params *jobCreateParams, ctop *v1alpha1.CAPTenantOperation, step
 
 // Collect tenant operation metrics based on the status of the tenant operation
 func collectTenantOperationMetrics(ctop *v1alpha1.CAPTenantOperation) {
+	relevantAppIdHash := ""
+	if _, ok := ctop.Labels[LabelAppIdHash]; ok {
+		relevantAppIdHash = ctop.Labels[LabelAppIdHash]
+	} else {
+		relevantAppIdHash = ctop.Labels[LabelBTPApplicationIdentifierHash]
+	}
+
 	if isCROConditionReady(ctop.Status.GenericStatus) {
 		// Collect/Increment overall completed tenant operation metrics
-		TenantOperations.WithLabelValues(ctop.Labels[LabelBTPApplicationIdentifierHash], string(ctop.Spec.Operation)).Inc()
+		TenantOperations.WithLabelValues(relevantAppIdHash, string(ctop.Spec.Operation)).Inc()
 
 		if ctop.Status.State == v1alpha1.CAPTenantOperationStateFailed {
 			// Collect/Increment failed tenant operation metrics with CRO details
-			TenantOperationFailures.WithLabelValues(ctop.Labels[LabelBTPApplicationIdentifierHash], string(ctop.Spec.Operation), ctop.Spec.TenantId, ctop.Namespace, ctop.Name).Inc()
+			TenantOperationFailures.WithLabelValues(relevantAppIdHash, string(ctop.Spec.Operation), ctop.Spec.TenantId, ctop.Namespace, ctop.Name).Inc()
 		}
 
 		// Collect tenant operation duration metrics based on creation time of the tenant operation and current time
-		LastTenantOperationDuration.WithLabelValues(ctop.Labels[LabelBTPApplicationIdentifierHash], ctop.Spec.TenantId).Set(time.Since(ctop.CreationTimestamp.Time).Seconds())
+		LastTenantOperationDuration.WithLabelValues(relevantAppIdHash, ctop.Spec.TenantId).Set(time.Since(ctop.CreationTimestamp.Time).Seconds())
 	}
 }

--- a/internal/controller/reconcile-networking.go
+++ b/internal/controller/reconcile-networking.go
@@ -446,7 +446,7 @@ func (c *Controller) reconcileServiceNetworking(ctx context.Context, ca *v1alpha
 		if reason != "" { // raise event only when there is a modification or problem
 			c.Event(cav, nil, eventType, reason, EventActionReconcileServiceNetworking, message)
 			// collect service operation metrics only if there is an error or modification on VirtualService
-			collectServiceOperationMetrics(cav, err)
+			collectServiceOperationMetrics(ca, cav, err)
 		}
 	}()
 

--- a/internal/controller/testdata/capapplicationversion/all-mulitple-content-job-completed-content-suffix.yaml
+++ b/internal/controller/testdata/capapplicationversion/all-mulitple-content-job-completed-content-suffix.yaml
@@ -144,12 +144,10 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-cap-backend-srv
     sme.sap.com/workload-type: CAP
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-cap-backend-srv
   namespace: default
@@ -183,12 +181,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default

--- a/internal/controller/testdata/capapplicationversion/all-mulitple-content-job-completed.yaml
+++ b/internal/controller/testdata/capapplicationversion/all-mulitple-content-job-completed.yaml
@@ -144,12 +144,10 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-cap-backend-srv
     sme.sap.com/workload-type: CAP
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-cap-backend-srv
   namespace: default
@@ -183,12 +181,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default

--- a/internal/controller/testdata/capapplicationversion/deployments-failure.yaml
+++ b/internal/controller/testdata/capapplicationversion/deployments-failure.yaml
@@ -7,12 +7,10 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-cap-backend-srv
     sme.sap.com/workload-type: CAP
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-cap-backend-srv
   namespace: default
@@ -58,12 +56,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default

--- a/internal/controller/testdata/capapplicationversion/deployments-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/deployments-ready.yaml
@@ -7,12 +7,10 @@ metadata:
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-cap-backend-srv
     sme.sap.com/workload-type: CAP
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-cap-backend-srv
   namespace: default
@@ -46,12 +44,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default

--- a/internal/controller/testdata/capapplicationversion/expected/cav-hpa-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-hpa-ready.yaml
@@ -97,14 +97,12 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   labels:
     app: test-cap-01
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-ca-01-cav-v1-cap-backend-service
     sme.sap.com/workload-type: Service
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862
@@ -129,14 +127,12 @@ apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   labels:
     app: test-cap-01
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-ca-01-cav-v1-app-router
     sme.sap.com/workload-type: Service
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862

--- a/internal/controller/testdata/capapplicationversion/expected/cav-pdb-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-pdb-ready.yaml
@@ -95,14 +95,12 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   labels:
     app: test-cap-01
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-ca-01-cav-v1-cap-backend-service
     sme.sap.com/workload-type: Service
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862
@@ -123,7 +121,6 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-ca-01-cav-v1-cap-backend-service
       sme.sap.com/workload-type: Service
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "0.0.1"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862
@@ -132,14 +129,12 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   labels:
     app: test-cap-01
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-ca-01-cav-v1-app-router
     sme.sap.com/workload-type: Service
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862
@@ -160,7 +155,6 @@ spec:
       sme.sap.com/category: Workload
       sme.sap.com/workload-name: test-ca-01-cav-v1-app-router
       sme.sap.com/workload-type: Service
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "0.0.1"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-affinity.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-affinity.yaml
@@ -197,12 +197,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -221,7 +219,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -234,12 +231,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-annotations.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-annotations.yaml
@@ -185,7 +185,6 @@ metadata:
   annotations:
     foo: "bar"
     sme.sap.com/some-custom-annotation: "some value for the annotation: 'sme.sap.com/some-custom-annotation'"
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   labels:
     app: test-cap-01
@@ -193,7 +192,6 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -214,7 +212,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -224,7 +221,6 @@ spec:
       annotations:
         foo: "bar"
         sme.sap.com/some-custom-annotation: "some value for the annotation: 'sme.sap.com/some-custom-annotation'"
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
       labels:
         app: test-cap-01
@@ -232,7 +228,6 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -293,11 +288,9 @@ metadata:
   annotations:
     foo: "bar"
     sme.sap.com/some-custom-annotation: "some value for the annotation: 'sme.sap.com/some-custom-annotation'"
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   labels:
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: Service
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router-svc
     sme.sap.com/workload-type: Router
@@ -324,7 +317,6 @@ spec:
       port: 4007
   selector:
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: Workload
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-cluster-netpol-port.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-cluster-netpol-port.yaml
@@ -171,12 +171,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -195,7 +193,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -208,12 +205,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:
@@ -278,13 +273,11 @@ spec:
         - podSelector:
             matchLabels:
               app: test-cap-01
-              sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
               sme.sap.com/category: Workload
               sme.sap.com/cav-version: "1.2.3"
   podSelector:
     matchLabels:
       app: test-cap-01
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Workload
       sme.sap.com/cav-version: "1.2.3"
   policyTypes:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-destination-config.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-destination-config.yaml
@@ -89,12 +89,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -113,7 +111,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -126,12 +123,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-labels-config.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-custom-labels-config.yaml
@@ -121,12 +121,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -147,7 +145,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -162,12 +159,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-init.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-init.yaml
@@ -222,12 +222,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -246,7 +244,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -259,12 +256,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-merged-destinations-router.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-merged-destinations-router.yaml
@@ -84,12 +84,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -108,7 +106,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -121,12 +118,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-prio.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-prio.yaml
@@ -181,12 +181,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -205,7 +203,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -218,12 +215,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-selector.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-node-selector.yaml
@@ -181,12 +181,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -205,7 +203,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -218,12 +215,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-pod-security-context.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-pod-security-context.yaml
@@ -185,12 +185,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -209,7 +207,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -222,12 +219,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-probes-and-resources.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-probes-and-resources.yaml
@@ -161,12 +161,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -185,7 +183,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -198,12 +195,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-security-context.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-security-context.yaml
@@ -174,12 +174,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -198,7 +196,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -211,12 +208,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-http-cookie-custom.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-http-cookie-custom.yaml
@@ -91,12 +91,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -115,7 +113,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -128,12 +125,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-http-header.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-http-header.yaml
@@ -85,12 +85,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -109,7 +107,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -122,12 +119,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-query-param.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-query-param.yaml
@@ -85,12 +85,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -109,7 +107,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -122,12 +119,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-source-ip.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-stickiness-source-ip.yaml
@@ -85,12 +85,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -109,7 +107,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -122,12 +119,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-toleration.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-toleration.yaml
@@ -189,12 +189,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -213,7 +211,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -226,12 +223,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-topology-autolabel.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-topology-autolabel.yaml
@@ -183,12 +183,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -207,7 +205,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -220,12 +217,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:
@@ -282,7 +277,6 @@ spec:
               sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
               sme.sap.com/workload-type: Router
               sme.sap.com/exposed-workload: "true"
-              sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
               sme.sap.com/cav-version: "1.2.3"
               sme.sap.com/owner-generation: "1"
               sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-topology.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-topology.yaml
@@ -188,12 +188,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -212,7 +210,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -225,12 +222,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-valid-env-config.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-valid-env-config.yaml
@@ -109,12 +109,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -133,7 +131,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -146,12 +143,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/expected/cav-ready-vol.yaml
+++ b/internal/controller/testdata/capapplicationversion/expected/cav-ready-vol.yaml
@@ -190,12 +190,10 @@ metadata:
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
     sme.sap.com/workload-type: Router
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "1.2.3"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   name: test-cap-01-cav-v1-app-router
   namespace: default
@@ -214,7 +212,6 @@ spec:
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
       sme.sap.com/workload-type: Router
       sme.sap.com/exposed-workload: "true"
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/cav-version: "1.2.3"
       sme.sap.com/owner-generation: "1"
       sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -227,12 +224,10 @@ spec:
         sme.sap.com/workload-name: test-cap-01-cav-v1-app-router
         sme.sap.com/workload-type: Router
         sme.sap.com/exposed-workload: "true"
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/cav-version: "1.2.3"
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
       annotations:
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
         sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
     spec:
       containers:

--- a/internal/controller/testdata/capapplicationversion/pdb-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/pdb-ready.yaml
@@ -8,12 +8,10 @@ metadata:
     sme.sap.com/workload-name: test-ca-01-cav-v1-cap-backend-service
     sme.sap.com/workload-type: Service
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-ca-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   name: test-ca-01-cav-v1-cap-backend-service
   namespace: default
@@ -47,12 +45,10 @@ metadata:
     sme.sap.com/workload-name: test-ca-01-cav-v1-app-router
     sme.sap.com/workload-type: Service
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: 00a7bd3cb89af3010bf21dcdc056f176adf3a862
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-ca-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   name: test-ca-01-cav-v1-app-router
   namespace: default

--- a/internal/controller/testdata/capapplicationversion/services-ready.yaml
+++ b/internal/controller/testdata/capapplicationversion/services-ready.yaml
@@ -8,12 +8,10 @@ metadata:
     sme.sap.com/workload-name: test-ca-01-cav-v1-cap-backend-service
     sme.sap.com/workload-type: Service
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-ca-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   name: test-ca-01-cav-v1-cap-backend-service
   namespace: default
@@ -47,12 +45,10 @@ metadata:
     sme.sap.com/workload-name: test-ca-01-cav-v1-app-router
     sme.sap.com/workload-type: Service
     sme.sap.com/exposed-workload: "true"
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "0.0.1"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-ca-01
     sme.sap.com/owner-identifier: default.test-ca-01-cav-v1
   name: test-ca-01-cav-v1-app-router
   namespace: default

--- a/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-04.expected.yaml
@@ -47,13 +47,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -72,13 +70,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/captenantoperation/ctop-06.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-06.expected.yaml
@@ -46,13 +46,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "cap-backend"
@@ -73,13 +71,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "cap-backend"

--- a/internal/controller/testdata/captenantoperation/ctop-07.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-07.expected.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-08.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-08.expected.yaml
@@ -49,13 +49,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -76,13 +74,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-08.initial.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-08.initial.yaml
@@ -49,13 +49,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -76,13 +74,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-09.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-09.expected.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "2"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "ten-op"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "2"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "ten-op"

--- a/internal/controller/testdata/captenantoperation/ctop-10.initial.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-10.initial.yaml
@@ -49,13 +49,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "2"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "ten-op"
@@ -76,13 +74,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "2"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "ten-op"

--- a/internal/controller/testdata/captenantoperation/ctop-11.initial.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-11.initial.yaml
@@ -49,13 +49,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "3"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -76,13 +74,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "3"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-12.initial.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-12.initial.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-13.initial.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-13.initial.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "2"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "ten-op"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "2"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "ten-op"

--- a/internal/controller/testdata/captenantoperation/ctop-16.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-16.expected.yaml
@@ -46,14 +46,12 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: deprovisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
     sme.sap.com/workload-type: "TenantOperation"
@@ -71,14 +69,12 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: deprovisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
         app: test-cap-01
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"
         sme.sap.com/workload-type: "TenantOperation"

--- a/internal/controller/testdata/captenantoperation/ctop-17.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-17.expected.yaml
@@ -46,14 +46,12 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: deprovisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
     sme.sap.com/workload-type: "TenantOperation"
@@ -71,14 +69,12 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: deprovisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
         app: test-cap-01
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"
         sme.sap.com/workload-type: "TenantOperation"

--- a/internal/controller/testdata/captenantoperation/ctop-17.initial.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-17.initial.yaml
@@ -45,14 +45,12 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: deprovisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
     sme.sap.com/workload-type: "TenantOperation"
@@ -70,14 +68,12 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: deprovisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
         app: test-cap-01
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"
         sme.sap.com/workload-type: "TenantOperation"

--- a/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-18.expected.yaml
@@ -47,13 +47,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -72,13 +70,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/captenantoperation/ctop-19.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-19.expected.yaml
@@ -46,14 +46,12 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: deprovisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
     sme.sap.com/workload-type: "TenantOperation"
@@ -71,14 +69,12 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: deprovisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
         app: test-cap-01
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"
         sme.sap.com/workload-type: "TenantOperation"

--- a/internal/controller/testdata/captenantoperation/ctop-20.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-20.expected.yaml
@@ -46,14 +46,12 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
     sme.sap.com/workload-type: "TenantOperation"
@@ -71,14 +69,12 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
         app: test-cap-01
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"
         sme.sap.com/workload-type: "TenantOperation"

--- a/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-21.expected.yaml
@@ -47,13 +47,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -72,13 +70,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-22.expected.yaml
@@ -47,13 +47,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -72,13 +70,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/captenantoperation/ctop-23.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-23.expected.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-24.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-24.expected.yaml
@@ -49,13 +49,11 @@ metadata:
     foo: "bar"
     sme.sap.com/my-custom-operation-identifier: "some value for the annotation: `sme.sap.com/my-custom-operation-identifier`"
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -76,13 +74,11 @@ spec:
         foo: "bar"
         sme.sap.com/my-custom-operation-identifier: "some value for the annotation: `sme.sap.com/my-custom-operation-identifier`"
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/captenantoperation/ctop-25.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-25.expected.yaml
@@ -52,13 +52,11 @@ metadata:
     foo: "bar"
     sme.sap.com/my-custom-app-identifier: "some value for the annotation: `sme.sap.com/my-custom-app-identifier`"
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -81,13 +79,11 @@ spec:
         foo: "bar"
         sme.sap.com/my-custom-app-identifier: "some value for the annotation: `sme.sap.com/my-custom-app-identifier`"
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-26.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-26.expected.yaml
@@ -46,14 +46,12 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "ten-op"
     sme.sap.com/workload-type: "TenantOperation"
@@ -73,14 +71,12 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
         app: test-cap-01
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "ten-op"
         sme.sap.com/workload-type: "TenantOperation"

--- a/internal/controller/testdata/captenantoperation/ctop-deprovisioning.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-deprovisioning.expected.yaml
@@ -46,14 +46,12 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: deprovisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
     app: test-cap-01
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
     sme.sap.com/workload-type: "TenantOperation"
@@ -71,14 +69,12 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: deprovisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
         app: test-cap-01
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"
         sme.sap.com/workload-type: "TenantOperation"

--- a/internal/controller/testdata/captenantoperation/ctop-init-custom.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-init-custom.expected.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-init.expected.yaml
@@ -47,13 +47,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -72,13 +70,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/captenantoperation/ctop-scheduling-custom.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-scheduling-custom.expected.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-scheduling.expected.yaml
@@ -47,13 +47,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -72,13 +70,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/captenantoperation/ctop-vol-custom.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-vol-custom.expected.yaml
@@ -50,13 +50,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: upgrade
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "custom-say"
@@ -77,13 +75,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: upgrade
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "custom-say"

--- a/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
+++ b/internal/controller/testdata/captenantoperation/ctop-vol.expected.yaml
@@ -47,13 +47,11 @@ kind: Job
 metadata:
   annotations:
     sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
   labels:
     sme.sap.com/tenant-operation-step: "1"
     sme.sap.com/tenant-operation-type: provisioning
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     app: test-cap-01
     sme.sap.com/category: "Workload"
     sme.sap.com/workload-name: "mtx"
@@ -72,13 +70,11 @@ spec:
     metadata:
       annotations:
         sme.sap.com/owner-identifier: default.test-cap-01-provider-abcd
-        sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
       labels:
         sme.sap.com/tenant-operation-step: "1"
         sme.sap.com/tenant-operation-type: provisioning
         sme.sap.com/owner-generation: "1"
         sme.sap.com/owner-identifier-hash: ce6bb3ae0b5ebbd0116259415ccac00bff0dc431
-        sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
         app: test-cap-01
         sme.sap.com/category: "Workload"
         sme.sap.com/workload-name: "mtx"

--- a/internal/controller/testdata/domain/domain-processing-dns.yaml
+++ b/internal/controller/testdata/domain/domain-processing-dns.yaml
@@ -34,7 +34,6 @@ metadata:
     sme.sap.com/resource-hash: 8d75feef05a17c4d0ac51fa33c1439065af397aefd5ba43c2defb44254ec4598
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 7f91a70a773eaf2e8e9c78020ddadf7f66119300

--- a/internal/controller/testdata/domain/domain-processing-old-dns.yaml
+++ b/internal/controller/testdata/domain/domain-processing-old-dns.yaml
@@ -34,7 +34,6 @@ metadata:
     sme.sap.com/resource-hash: bcec92268a567aadc243d28dda4ad857a41a858964b920c77f6376849e660419
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/subdomain-hash: df58248c414f342c81e056b40bee12d17a08bf61

--- a/internal/controller/testdata/domain/domain-processing-updated-dns.yaml
+++ b/internal/controller/testdata/domain/domain-processing-updated-dns.yaml
@@ -34,7 +34,6 @@ metadata:
     sme.sap.com/resource-hash: 8d75feef05a17c4d0ac51fa33c1439065af397aefd5ba43c2defb44254ec4598
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 7f91a70a773eaf2e8e9c78020ddadf7f66119300

--- a/internal/controller/testdata/domain/domain-update.expected-certManager.yaml
+++ b/internal/controller/testdata/domain/domain-update.expected-certManager.yaml
@@ -66,7 +66,6 @@ metadata:
     sme.sap.com/resource-hash: 4c5ea718c70d8b8302c1735d7e354da96845be52b85f17366f47f9cfcaaf8238
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 3ac8d1a341cef9a79b0e7a9115bc65406ed9b656

--- a/internal/controller/testdata/domain/domain-update.expected.yaml
+++ b/internal/controller/testdata/domain/domain-update.expected.yaml
@@ -66,7 +66,6 @@ metadata:
     sme.sap.com/resource-hash: 4c5ea718c70d8b8302c1735d7e354da96845be52b85f17366f47f9cfcaaf8238
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 3ac8d1a341cef9a79b0e7a9115bc65406ed9b656

--- a/internal/controller/testdata/domain/domain-with-customDNS-services.yaml
+++ b/internal/controller/testdata/domain/domain-with-customDNS-services.yaml
@@ -39,7 +39,6 @@ metadata:
     sme.sap.com/resource-hash: 8d75feef05a17c4d0ac51fa33c1439065af397aefd5ba43c2defb44254ec4598
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 7f91a70a773eaf2e8e9c78020ddadf7f66119300
@@ -66,10 +65,9 @@ metadata:
   annotations:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: c44f04c4168d68874699d4c67ae310a8bfb26f89123514ace9aac0de7fed86d5
+    sme.sap.com/resource-hash: 628a3a3718cc233a21b155189563a54ffc2fa21ffa57263b29ac208bd07dcf32
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: "f20cc8aeb2003b3abc33f749a16bd53544b6bab2"
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 40c43e43bedecd7666574294ad60228aa7e7e19c

--- a/internal/controller/testdata/domain/domain-with-customDNS-tenant.yaml
+++ b/internal/controller/testdata/domain/domain-with-customDNS-tenant.yaml
@@ -39,7 +39,6 @@ metadata:
     sme.sap.com/resource-hash: 8d75feef05a17c4d0ac51fa33c1439065af397aefd5ba43c2defb44254ec4598
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 7f91a70a773eaf2e8e9c78020ddadf7f66119300
@@ -66,10 +65,9 @@ metadata:
   annotations:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: f7d8607816375cbf59341c4484e03581326752e2610a0db7fd14c3d085a61d7b
+    sme.sap.com/resource-hash: a397f0ea92c4bbc3481abab13e2216531e81c24d871137f6effd3d2f362152fb
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: "f20cc8aeb2003b3abc33f749a16bd53544b6bab2"
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: cb09eb96e7f06d6645216e015230ca1081d939f4

--- a/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol-cat.yaml
+++ b/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol-cat.yaml
@@ -31,10 +31,9 @@ metadata:
   annotations:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: f7d8607816375cbf59341c4484e03581326752e2610a0db7fd14c3d085a61d7b
+    sme.sap.com/resource-hash: a397f0ea92c4bbc3481abab13e2216531e81c24d871137f6effd3d2f362152fb
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: "f20cc8aeb2003b3abc33f749a16bd53544b6bab2"
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: cb09eb96e7f06d6645216e015230ca1081d939f4

--- a/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol.yaml
+++ b/internal/controller/testdata/domain/domain-with-subdomain-processing-with-dns-netpol.yaml
@@ -31,10 +31,9 @@ metadata:
   annotations:
     dns.gardener.cloud/class: garden
     sme.sap.com/owner-identifier: Domain.default.test-cap-01-primary
-    sme.sap.com/resource-hash: c44f04c4168d68874699d4c67ae310a8bfb26f89123514ace9aac0de7fed86d5
+    sme.sap.com/resource-hash: 628a3a3718cc233a21b155189563a54ffc2fa21ffa57263b29ac208bd07dcf32
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: "f20cc8aeb2003b3abc33f749a16bd53544b6bab2"
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 40c43e43bedecd7666574294ad60228aa7e7e19c

--- a/internal/controller/testdata/domain/primary-dns-error.yaml
+++ b/internal/controller/testdata/domain/primary-dns-error.yaml
@@ -7,7 +7,6 @@ metadata:
     sme.sap.com/resource-hash: 8d75feef05a17c4d0ac51fa33c1439065af397aefd5ba43c2defb44254ec4598
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 7f91a70a773eaf2e8e9c78020ddadf7f66119300

--- a/internal/controller/testdata/domain/primary-dns-ready.yaml
+++ b/internal/controller/testdata/domain/primary-dns-ready.yaml
@@ -7,7 +7,6 @@ metadata:
     sme.sap.com/resource-hash: 8d75feef05a17c4d0ac51fa33c1439065af397aefd5ba43c2defb44254ec4598
   generateName: test-cap-01-primary-
   labels:
-    sme.sap.com/btp-app-identifier-hash: ""
     sme.sap.com/owner-generation: "0"
     sme.sap.com/owner-identifier-hash: f3b9e769089130d9d80dc05b68fb1564beb8cccc
     sme.sap.com/dns-name-hash: 7f91a70a773eaf2e8e9c78020ddadf7f66119300

--- a/internal/controller/testdata/version-monitoring/servicemonitors-cav-v1.yaml
+++ b/internal/controller/testdata/version-monitoring/servicemonitors-cav-v1.yaml
@@ -2,14 +2,12 @@ apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   annotations:
-    sme.sap.com/btp-app-identifier: btp-glo-acc-id.test-cap-01
     sme.sap.com/owner-identifier: default.test-cap-01-cav-v1
   labels:
     app: test-cap-01
     sme.sap.com/category: ServiceMonitor
     sme.sap.com/workload-name: test-cap-01-cav-v1-app-router-svc
     sme.sap.com/workload-type: Router
-    sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
     sme.sap.com/cav-version: "5.6.7"
     sme.sap.com/owner-generation: "1"
     sme.sap.com/owner-identifier-hash: e95e0682f33a657e75e1fc435972d19bd407ba3b
@@ -31,7 +29,6 @@ spec:
   selector:
     matchLabels:
       app: test-cap-01
-      sme.sap.com/btp-app-identifier-hash: f20cc8aeb2003b3abc33f749a16bd53544b6bab2
       sme.sap.com/category: Service
       sme.sap.com/cav-version: "5.6.7"
       sme.sap.com/workload-name: test-cap-01-cav-v1-app-router-svc

--- a/internal/controller/utils.go
+++ b/internal/controller/utils.go
@@ -223,13 +223,15 @@ func updateLabelAnnotationMetadata(object *metav1.ObjectMeta, appMetadata *appMe
 		object.Annotations = map[string]string{}
 	}
 
-	// Update BTP Application Identifier
-	if appMetadata.globalAccountId != "" && amendObjectMetadata(object, AnnotationBTPApplicationIdentifier, LabelBTPApplicationIdentifierHash, strings.Join([]string{appMetadata.globalAccountId, appMetadata.appName}, "."), sha1Sum(appMetadata.globalAccountId, appMetadata.appName)) {
-		updated = true
-	}
-
 	// Update App Identifier
-	if appMetadata.providerSubaccountId != "" && amendObjectMetadata(object, AnnotationAppId, LabelAppIdHash, strings.Join([]string{appMetadata.providerSubaccountId, appMetadata.appName}, "."), sha1Sum(appMetadata.providerSubaccountId, appMetadata.appName)) {
+	if appMetadata.providerSubaccountId != "" {
+		if amendObjectMetadata(object, AnnotationAppId, LabelAppIdHash, strings.Join([]string{appMetadata.providerSubaccountId, appMetadata.appName}, "."), sha1Sum(appMetadata.providerSubaccountId, appMetadata.appName)) {
+			// When new appId is set, get rid of former identifier BTPAppId label and hash
+			delete(object.Annotations, AnnotationBTPApplicationIdentifier)
+			delete(object.Labels, LabelBTPApplicationIdentifierHash)
+			updated = true
+		}
+	} else if appMetadata.globalAccountId != "" && amendObjectMetadata(object, AnnotationBTPApplicationIdentifier, LabelBTPApplicationIdentifierHash, strings.Join([]string{appMetadata.globalAccountId, appMetadata.appName}, "."), sha1Sum(appMetadata.globalAccountId, appMetadata.appName)) {
 		updated = true
 	}
 

--- a/pkg/apis/sme.sap.com/v1alpha1/types.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/types.go
@@ -87,17 +87,18 @@ type CAPApplicationList struct {
 }
 
 // CAPApplicationSpec defines the desired state of CAPApplication
+// +kubebuilder:validation:AtLeastOneOf=globalAccountId;providerSubaccountId
 type CAPApplicationSpec struct {
-	// Domains used by the application (new)
+	// Reference to `Domain` resources used by the application
 	DomainRefs []DomainRef `json:"domainRefs,omitempty"`
-	// [DEPRECATED] Domains used by the application // Will be removed in future versions
+	// Deprecated: Domains used by the application. Will be removed in future versions, use `DomainRefs` instead
 	Domains ApplicationDomains `json:"domains,omitempty"`
-	// SAP BTP Global Account Identifier where services are entitled for the current application
-	// Will soon be deprecated, use ProviderSubaccountId instead
-	GlobalAccountId string `json:"globalAccountId"`
+	// Deprecated: SAP BTP Global Account Identifier where services are entitled for the current application
+	// Will be removed soon, use ProviderSubaccountId instead
+	GlobalAccountId string `json:"globalAccountId,omitempty"`
 	// The subaccount ID in which the application is provided (will soon replace GlobalAccountId)
 	ProviderSubaccountId string `json:"providerSubaccountId,omitempty"`
-	// Short name for the application (similar to BTP XSAPPNAME)
+	// Short name for the application (BTP XSAPPNAME)
 	BTPAppName string `json:"btpAppName"`
 	// Provider subaccount where application services are created
 	Provider *BTPTenantIdentification `json:"provider,omitempty"`

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/capapplicationspec.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/capapplicationspec.go
@@ -12,16 +12,16 @@ package v1alpha1
 //
 // CAPApplicationSpec defines the desired state of CAPApplication
 type CAPApplicationSpecApplyConfiguration struct {
-	// Domains used by the application (new)
+	// Reference to `Domain` resources used by the application
 	DomainRefs []DomainRefApplyConfiguration `json:"domainRefs,omitempty"`
-	// [DEPRECATED] Domains used by the application // Will be removed in future versions
+	// Deprecated: Domains used by the application. Will be removed in future versions, use `DomainRefs` instead
 	Domains *ApplicationDomainsApplyConfiguration `json:"domains,omitempty"`
-	// SAP BTP Global Account Identifier where services are entitled for the current application
-	// Will soon be deprecated, use ProviderSubaccountId instead
+	// Deprecated: SAP BTP Global Account Identifier where services are entitled for the current application
+	// Will be removed soon, use ProviderSubaccountId instead
 	GlobalAccountId *string `json:"globalAccountId,omitempty"`
 	// The subaccount ID in which the application is provided (will soon replace GlobalAccountId)
 	ProviderSubaccountId *string `json:"providerSubaccountId,omitempty"`
-	// Short name for the application (similar to BTP XSAPPNAME)
+	// Short name for the application (BTP XSAPPNAME)
 	BTPAppName *string `json:"btpAppName,omitempty"`
 	// Provider subaccount where application services are created
 	Provider *BTPTenantIdentificationApplyConfiguration `json:"provider,omitempty"`


### PR DESCRIPTION
Further changes to replace `globalAccountId` with `providerSubaccountId`.
- Deprecate `globalAccountId` and make it optional
We now check if `providerSubaccountId` is specified. If so:
- Generate new appId based labels/annotations for Operator resources.

This change also gets rid of btp-app-id based labels/annotations from
non operator child resources (Jobs, Deployments, Services etc..).

Temp: Introduced a CEL check to ensure at least one of the values i.e.
`globalAccountId` or `providerSubaccountId` is set.