### PR TITLE
[Misc] informers: queue mapping updated

### DIFF
--- a/internal/controller/common_test.go
+++ b/internal/controller/common_test.go
@@ -272,7 +272,6 @@ func initializeControllerForReconciliationTests(t *testing.T, items []ResourceAc
 	istioClient.PrependReactor("*", "*", getErrorReactorWithResources(items))
 
 	coreClient.PrependReactor("create", "*", generateNameCreateHandler)
-	coreClient.PrependReactor("create", "*", generateNameCreateHandler)
 	coreClient.PrependReactor("*", "*", getErrorReactorWithResources(items))
 
 	gardenerDNSClient.PrependReactor("create", "*", generateNameCreateHandler)
@@ -285,6 +284,7 @@ func initializeControllerForReconciliationTests(t *testing.T, items []ResourceAc
 
 	c := NewController(coreClient, copClient, istioClient, gardenerCertClient, certManagerClient, gardenerDNSClient, promopClient)
 	c.eventRecorder = events.NewFakeRecorder(10)
+
 	return c
 }
 
@@ -509,7 +509,7 @@ func addInitialObjectToStore(resource []byte, c *Controller) error {
 	}
 
 	switch obj.(type) {
-	case *corev1.Secret, *corev1.Pod, *corev1.Namespace, *corev1.Service:
+	case *corev1.Secret, *corev1.Pod, *corev1.Namespace, *corev1.Service, *appsv1.Deployment, *batchv1.Job, *networkingv1.NetworkPolicy, *discoveryv1.EndpointSlice:
 		fakeClient, ok := c.kubeClient.(*k8sfake.Clientset)
 		if !ok {
 			return fmt.Errorf("controller is not using a fake clientset")
@@ -524,21 +524,16 @@ func addInitialObjectToStore(resource []byte, c *Controller) error {
 			err = c.kubeInformerFactory.Core().V1().Namespaces().Informer().GetIndexer().Add(obj)
 		case *corev1.Service:
 			err = c.kubeInformerFactory.Core().V1().Services().Informer().GetIndexer().Add(obj)
+
+		case *appsv1.Deployment:
+			err = c.kubeInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(obj)
+
+		case *batchv1.Job:
+			err = c.kubeInformerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(obj)
+
+		case *networkingv1.NetworkPolicy:
+			err = c.kubeInformerFactory.Networking().V1().NetworkPolicies().Informer().GetIndexer().Add(obj)
 		}
-	case *appsv1.Deployment:
-		fakeClient, ok := c.kubeClient.(*k8sfake.Clientset)
-		if !ok {
-			return fmt.Errorf("controller is not using a fake clientset")
-		}
-		fakeClient.Tracker().Add(obj)
-		err = c.kubeInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(obj)
-	case *batchv1.Job:
-		fakeClient, ok := c.kubeClient.(*k8sfake.Clientset)
-		if !ok {
-			return fmt.Errorf("controller is not using a fake clientset")
-		}
-		fakeClient.Tracker().Add(obj)
-		err = c.kubeInformerFactory.Batch().V1().Jobs().Informer().GetIndexer().Add(obj)
 	case *gardenercertv1alpha1.Certificate:
 		fakeClient, ok := c.gardenerCertificateClient.(*gardenercertfake.Clientset)
 		if !ok {
@@ -560,13 +555,6 @@ func addInitialObjectToStore(resource []byte, c *Controller) error {
 		}
 		fakeClient.Tracker().Add(obj)
 		err = c.gardenerDNSInformerFactory.Dns().V1alpha1().DNSEntries().Informer().GetIndexer().Add(obj)
-	case *networkingv1.NetworkPolicy:
-		fakeClient, ok := c.kubeClient.(*k8sfake.Clientset)
-		if !ok {
-			return fmt.Errorf("controller is not using a fake clientset")
-		}
-		fakeClient.Tracker().Add(obj)
-		err = c.kubeInformerFactory.Networking().V1().NetworkPolicies().Informer().GetIndexer().Add(obj)
 	case *istionwv1.Gateway, *istionwv1.VirtualService, *istionwv1.DestinationRule:
 		fakeClient, ok := c.istioClient.(*istiofake.Clientset)
 		if !ok {
@@ -609,12 +597,6 @@ func addInitialObjectToStore(resource []byte, c *Controller) error {
 		}
 	case *monv1.ServiceMonitor:
 		fakeClient, ok := c.promClient.(*promopFake.Clientset)
-		if !ok {
-			return fmt.Errorf("controller is not using a fake clientset")
-		}
-		fakeClient.Tracker().Add(obj)
-	case *discoveryv1.EndpointSlice:
-		fakeClient, ok := c.kubeClient.(*k8sfake.Clientset)
 		if !ok {
 			return fmt.Errorf("controller is not using a fake clientset")
 		}

--- a/internal/controller/informers.go
+++ b/internal/controller/informers.go
@@ -16,14 +16,14 @@ import (
 )
 
 const (
-	ResourceCAPTenant = iota
+	ResourceCAPApplication = iota
 	ResourceCAPApplicationVersion
-	ResourceCAPApplication
+	ResourceCAPTenant
 	ResourceCAPTenantOperation
-	ResourceClusterDomain
 	ResourceDomain
-	ResourceJob
+	ResourceClusterDomain
 	ResourceSecret
+	ResourceJob
 	ResourceGateway
 	ResourceCertificate
 	ResourceDNSEntry
@@ -31,20 +31,16 @@ const (
 	ResourceDestinationRule
 )
 
-const (
-	OperatorDomains = "OperatorDomains"
-)
-
 const queuing = "queuing resource for reconciliation"
 
 var (
 	KindMap = map[int]string{
-		ResourceCAPTenant:             v1alpha1.CAPTenantKind,
-		ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind,
 		ResourceCAPApplication:        v1alpha1.CAPApplicationKind,
+		ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind,
+		ResourceCAPTenant:             v1alpha1.CAPTenantKind,
 		ResourceCAPTenantOperation:    v1alpha1.CAPTenantOperationKind,
-		ResourceClusterDomain:         v1alpha1.ClusterDomainKind,
 		ResourceDomain:                v1alpha1.DomainKind,
+		ResourceClusterDomain:         v1alpha1.ClusterDomainKind,
 	}
 )
 
@@ -54,19 +50,19 @@ type NamespacedResourceKey struct {
 }
 
 var QueueMapping map[int]map[int]string = map[int]map[int]string{
-	ResourceCAPTenantOperation:    {ResourceCAPTenantOperation: v1alpha1.CAPTenantOperationKind, ResourceCAPTenant: v1alpha1.CAPTenantKind},
-	ResourceJob:                   {ResourceCAPTenantOperation: v1alpha1.CAPTenantOperationKind, ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind},
-	ResourceSecret:                {ResourceCAPApplication: v1alpha1.CAPApplicationKind, ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind},
-	ResourceGateway:               {ResourceCAPApplication: v1alpha1.CAPApplicationKind},
-	ResourceCertificate:           {ResourceCAPApplication: v1alpha1.CAPApplicationKind},
-	ResourceDNSEntry:              {ResourceCAPApplication: v1alpha1.CAPApplicationKind, ResourceCAPTenant: v1alpha1.CAPTenantKind},
+	ResourceCAPApplication:        {ResourceCAPApplication: v1alpha1.CAPApplicationKind},
+	ResourceCAPApplicationVersion: {ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind, ResourceCAPApplication: v1alpha1.CAPApplicationKind},
 	ResourceCAPTenant:             {ResourceCAPTenant: v1alpha1.CAPTenantKind, ResourceCAPApplication: v1alpha1.CAPApplicationKind},
+	ResourceCAPTenantOperation:    {ResourceCAPTenantOperation: v1alpha1.CAPTenantOperationKind, ResourceCAPTenant: v1alpha1.CAPTenantKind},
+	ResourceDomain:                {ResourceDomain: v1alpha1.DomainKind},
+	ResourceClusterDomain:         {ResourceClusterDomain: v1alpha1.ClusterDomainKind},
+	ResourceSecret:                {ResourceCAPApplication: v1alpha1.CAPApplicationKind, ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind},
+	ResourceJob:                   {ResourceCAPTenantOperation: v1alpha1.CAPTenantOperationKind, ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind},
+	ResourceGateway:               {ResourceDomain: v1alpha1.DomainKind, ResourceClusterDomain: v1alpha1.ClusterDomainKind},
+	ResourceCertificate:           {ResourceDomain: v1alpha1.DomainKind, ResourceClusterDomain: v1alpha1.ClusterDomainKind},
+	ResourceDNSEntry:              {ResourceDomain: v1alpha1.DomainKind, ResourceClusterDomain: v1alpha1.ClusterDomainKind},
 	ResourceVirtualService:        {ResourceCAPTenant: v1alpha1.CAPTenantKind},
 	ResourceDestinationRule:       {ResourceCAPTenant: v1alpha1.CAPTenantKind},
-	ResourceCAPApplicationVersion: {ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind, ResourceCAPApplication: v1alpha1.CAPApplicationKind},
-	ResourceCAPApplication:        {ResourceCAPApplication: v1alpha1.CAPApplicationKind},
-	ResourceClusterDomain:         {ResourceClusterDomain: v1alpha1.ClusterDomainKind},
-	ResourceDomain:                {ResourceDomain: v1alpha1.DomainKind},
 }
 
 type QueueItem struct {
@@ -75,14 +71,14 @@ type QueueItem struct {
 }
 
 func (c *Controller) initializeInformers() {
-	c.registerCAPTenantListeners()
 	c.registerCAPApplicationListeners()
 	c.registerCAPApplicationVersionListeners()
+	c.registerCAPTenantListeners()
 	c.registerCAPTenantOperationListeners()
-	c.registerClusterDomainListeners()
 	c.registerDomainListeners()
-	c.registerJobListeners()
+	c.registerClusterDomainListeners()
 	c.registerSecretListeners()
+	c.registerJobListeners()
 	c.registerGatewayListeners()
 	c.registerVirtualServiceListeners()
 	c.registerDestinationRuleListeners()

--- a/internal/controller/informers_test.go
+++ b/internal/controller/informers_test.go
@@ -95,7 +95,8 @@ func TestController_initializeInformers(t *testing.T) {
 				ResourceCAPApplicationVersion: &dummyType{},
 				ResourceCAPTenant:             &dummyType{},
 				ResourceCAPTenantOperation:    &dummyType{},
-				// ResourceOperatorDomains:       &dummyType{},
+				ResourceDomain:                &dummyType{},
+				ResourceClusterDomain:         &dummyType{},
 			}
 
 			testC := &Controller{
@@ -125,9 +126,9 @@ func TestController_initializeInformers(t *testing.T) {
 			case ResourceCertificate:
 				// set label on a pod to simulate certificate in a different namespace
 				cert := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: tt.itemName, Annotations: map[string]string{
-					AnnotationOwnerIdentifier: KindMap[ResourceCAPApplication] + "." + tt.itemNamespace + "." + tt.itemName,
+					AnnotationOwnerIdentifier: KindMap[ResourceDomain] + "." + tt.itemNamespace + "." + tt.itemName,
 				}, Labels: map[string]string{
-					LabelOwnerIdentifierHash: sha1Sum(KindMap[ResourceCAPApplication], tt.itemNamespace, tt.itemName),
+					LabelOwnerIdentifierHash: sha1Sum(KindMap[ResourceDomain], tt.itemNamespace, tt.itemName),
 				}}}
 				// Invalid label
 				if tt.invalidOwnerRef {

--- a/internal/controller/reconcile-captenantoperation.go
+++ b/internal/controller/reconcile-captenantoperation.go
@@ -79,8 +79,7 @@ const (
 )
 
 func (c *Controller) reconcileCAPTenantOperation(ctx context.Context, item QueueItem, _ int) (result *ReconcileResult, err error) {
-	// cached, err := c.crdInformerFactory.Sme().V1alpha1().CAPTenantOperations().Lister().CAPTenantOperations(item.ResourceKey.Namespace).Get(item.ResourceKey.Name)
-	cached, err := c.crdClient.SmeV1alpha1().CAPTenantOperations(item.ResourceKey.Namespace).Get(ctx, item.ResourceKey.Name, metav1.GetOptions{})
+	cached, err := c.crdInformerFactory.Sme().V1alpha1().CAPTenantOperations().Lister().CAPTenantOperations(item.ResourceKey.Namespace).Get(item.ResourceKey.Name)
 
 	if err != nil {
 		return nil, handleOperatorResourceErrors(err)


### PR DESCRIPTION
- Use consistent ordering
- Fix queue mapping for notifications (Domain should now be notified when GW, Cert or DNS is updated)
 - use informer cache while fetching tenant operation!