### PR TITLE
[Misc] workflow: Fixed version used

### DIFF
--- a/.github/workflows/publish-website.yaml
+++ b/.github/workflows/publish-website.yaml
@@ -60,7 +60,7 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v5
+        uses: actions/upload-pages-artifact@v5.0.0
         with:
           path: website/public
 


### PR DESCRIPTION
The workflow to create v5 tag is still pending:
https://github.com/actions/upload-pages-artifact/actions/runs/24257710031