### PR TITLE
[Misc] docu: Banner mentioning required action added

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@
 [![OpenSSF Best Practices](https://www.bestpractices.dev/projects/7803/badge)](https://www.bestpractices.dev/projects/7803)
 [![REUSE status](https://api.reuse.software/badge/github.com/SAP/cap-operator)](https://api.reuse.software/info/github.com/SAP/cap-operator)
 
+> [!WARNING]
+> ## Action Required:
+> As [announced](https://github.com/SAP/cap-operator/discussions/343), the `globalAccountId` field in the `CAPApplication` spec is deprecated and will be removed in a future release. Update your `CAPApplication` resources to use `providerSubaccountId` instead.
+
 CAP Operator manages the lifecycle operations involved in running multi-tenant CAP applications on Kubernetes clusters, primarily project "Gardener" managed clusters.
 
 #### Documentation

--- a/website/content/en/docs/usage/deploying-application.md
+++ b/website/content/en/docs/usage/deploying-application.md
@@ -168,7 +168,3 @@ Once these resources are available, the `CAPApplicationVersion` status changes t
 > The `CAPApplicationVersion` resource is immutable — its spec must not be modified after deployment. This is enforced by webhooks, which we recommend keeping active (the default).
 
 > NOTE: Follow the recommended [security measures](../security) to safeguard exposed workloads.
-
-{{% alert color="warning" title="Warning" %}}
-The `globalSubaccountId` field in the `CAPApplication` spec is deprecated and will be removed in a future release. Use `providerSubaccountId` instead.
-{{% /alert %}}

--- a/website/content/en/docs/usage/resources/capapplication.md
+++ b/website/content/en/docs/usage/resources/capapplication.md
@@ -63,7 +63,3 @@ The `domainRefs` section references one or more `Domain` or `ClusterDomain` reso
 > NOTE: While the same secondary domain can technically be shared across applications using `ClusterDomain`, tenant subdomains must be unique across all applications sharing that domain.
 
 > NOTE: The `provider` section is omitted for [services-only applications](../../service-exposure/#deploying-services-only-applications).
-
-{{% alert color="warning" title="Warning" %}}
-The `globalSubaccountId` field in the `CAPApplication` spec is deprecated and will be removed in a future release. Use `providerSubaccountId` instead.
-{{% /alert %}}

--- a/website/layouts/_partials/version-banner.html
+++ b/website/layouts/_partials/version-banner.html
@@ -1,0 +1,4 @@
+<div class="alert alert-warning" role="alert">
+    <div class="h4 alert-heading" role="alertdialog">Action Required</div>
+    <p>The <code>globalAccountId</code> field in the <code>CAPApplication</code> spec is deprecated and will be removed in a future release. Update your <code>CAPApplication</code> resources to use <code>providerSubaccountId</code> instead.</p>
+</div>


### PR DESCRIPTION
Make it clear that:
the `globalSubaccountId` field in the `CAPApplication` spec is deprecated and will be removed in a future release. Update your `CAPApplication` resources to use `providerSubaccountId` instead.