### PR TITLE
[Misc] Operator: minor updates for providerSubaccountId

### DIFF
--- a/cmd/server/internal/handler.go
+++ b/cmd/server/internal/handler.go
@@ -406,13 +406,13 @@ func (s *SubscriptionHandler) updateSecret(tenant *v1alpha1.CAPTenant, secret *c
 	return err
 }
 
-func (s *SubscriptionHandler) getTenantByAppIdentifier(globalAccountGUID, providerSubAccountId, btpAppName, tenantId, namespace, step string) (result *Result) {
+func (s *SubscriptionHandler) getTenantByAppIdentifier(globalAccountGUID, providerSubaccountId, btpAppName, tenantId, namespace, step string) (result *Result) {
 	tenantlabels := map[string]string{
 		LabelTenantId: tenantId,
 	}
 
 	labelsMaps := maps.Clone(tenantlabels)
-	labelsMaps[LabelAppIdHash] = sha1Sum(providerSubAccountId, btpAppName)
+	labelsMaps[LabelAppIdHash] = sha1Sum(providerSubaccountId, btpAppName)
 
 	if result = s.getTenantByLabels(labelsMaps, namespace, step, "getTenantByAppIdentifier"); result.Tenant == nil {
 		oldLabelsMap := maps.Clone(tenantlabels)

--- a/internal/controller/reconcile-capapplication.go
+++ b/internal/controller/reconcile-capapplication.go
@@ -429,22 +429,22 @@ func (c *Controller) reconcileCAPApplicationProviderTenant(ctx context.Context, 
 }
 
 func (c *Controller) createProviderTenant(ctx context.Context, ca *v1alpha1.CAPApplication, version string, providerTenantName string) (tenant *v1alpha1.CAPTenant, err error) {
-	providerSubaccountId := ""
+	providerSubaccountId := ca.Spec.ProviderSubaccountId
 	tenantLabels := map[string]string{
 		LabelTenantId: ca.Spec.Provider.TenantId,
 	}
-	// Create a secret with the provider subscription context (dervied from the spec of CAPApplication)
-	if ca.Spec.ProviderSubaccountId != "" {
-		providerSubaccountId = ca.Spec.ProviderSubaccountId
-	} else {
-		// Try to get the provider subaccount id from the annotations
-		providerSubaccountId = ca.Annotations[AnnotationProviderSubAccountId]
+
+	if providerSubaccountId == "" {
 		// If no provider subaccount id annotation is found use provider tenantId that is needed because some cds / hana APIs seem to rely on this field instead of tenantId!
-		if providerSubaccountId == "" {
-			providerSubaccountId = ca.Spec.Provider.TenantId
-		}
+		providerSubaccountId = ca.Spec.Provider.TenantId
 	}
 
+	globalAccountGUID := ca.Spec.GlobalAccountId
+	if globalAccountGUID == "" {
+		globalAccountGUID = ca.Annotations[AnnotationGlobalAccountId]
+	}
+
+	// Create a secret with the provider subscription context (dervied from the spec of CAPApplication)
 	secret, err := c.kubeClient.CoreV1().Secrets(ca.Namespace).Create(context.TODO(), &corev1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
 			GenerateName: providerTenantName + "-",
@@ -457,7 +457,7 @@ func (c *Controller) createProviderTenant(ctx context.Context, ca *v1alpha1.CAPA
 					"subscribedTenantId": "` + ca.Spec.Provider.TenantId + `",
 					"subscribedSubaccountId": "` + providerSubaccountId + `",
 					"subscribedSubdomain": "` + ca.Spec.Provider.SubDomain + `",
-					"globalAccountGUID": "` + ca.Spec.GlobalAccountId + `"
+					"globalAccountGUID": "` + globalAccountGUID + `"
 				}`,
 		},
 	}, metav1.CreateOptions{})

--- a/internal/controller/reconcile-captenantoperation.go
+++ b/internal/controller/reconcile-captenantoperation.go
@@ -423,17 +423,18 @@ func (c *Controller) initiateJobForCAPTenantOperationStep(ctx context.Context, c
 	})
 
 	params := &jobCreateParams{
-		namePrefix:        relatedResources.CAPTenant.Name + "-" + workload.Name + "-",
-		labels:            labels,
-		annotations:       annotations,
-		vcapSecretName:    vcapSecretName,
-		imagePullSecrets:  convertToLocalObjectReferences(relatedResources.CAPApplicationVersion.Spec.RegistrySecrets),
-		version:           relatedResources.CAPApplicationVersion.Spec.Version,
-		appName:           relatedResources.CAPApplication.Spec.BTPAppName,
-		globalAccountId:   relatedResources.CAPApplication.Spec.GlobalAccountId,
-		providerTenantId:  relatedResources.CAPApplication.Spec.Provider.TenantId,
-		providerSubdomain: relatedResources.CAPApplication.Spec.Provider.SubDomain,
-		tenantType:        relatedResources.CAPTenant.Labels[LabelTenantType],
+		namePrefix:           relatedResources.CAPTenant.Name + "-" + workload.Name + "-",
+		labels:               labels,
+		annotations:          annotations,
+		vcapSecretName:       vcapSecretName,
+		imagePullSecrets:     convertToLocalObjectReferences(relatedResources.CAPApplicationVersion.Spec.RegistrySecrets),
+		version:              relatedResources.CAPApplicationVersion.Spec.Version,
+		appName:              relatedResources.CAPApplication.Spec.BTPAppName,
+		globalAccountId:      relatedResources.CAPApplication.Spec.GlobalAccountId,
+		providerSubaccountId: relatedResources.CAPApplication.Spec.ProviderSubaccountId,
+		providerTenantId:     relatedResources.CAPApplication.Spec.Provider.TenantId,
+		providerSubdomain:    relatedResources.CAPApplication.Spec.Provider.SubDomain,
+		tenantType:           relatedResources.CAPTenant.Labels[LabelTenantType],
 	}
 
 	var job *batchv1.Job
@@ -457,17 +458,18 @@ func (c *Controller) initiateJobForCAPTenantOperationStep(ctx context.Context, c
 }
 
 type jobCreateParams struct {
-	namePrefix        string
-	labels            map[string]string
-	annotations       map[string]string
-	vcapSecretName    string
-	imagePullSecrets  []corev1.LocalObjectReference
-	version           string
-	appName           string
-	globalAccountId   string
-	providerTenantId  string
-	providerSubdomain string
-	tenantType        string
+	namePrefix           string
+	labels               map[string]string
+	annotations          map[string]string
+	vcapSecretName       string
+	imagePullSecrets     []corev1.LocalObjectReference
+	version              string
+	appName              string
+	globalAccountId      string
+	providerSubaccountId string
+	providerTenantId     string
+	providerSubdomain    string
+	tenantType           string
 }
 
 func (c *Controller) createTenantOperationJob(ctx context.Context, ctop *v1alpha1.CAPTenantOperation, workload *v1alpha1.WorkloadDetails, params *jobCreateParams) (*batchv1.Job, error) {
@@ -709,6 +711,10 @@ func getCTOPEnv(params *jobCreateParams, ctop *v1alpha1.CAPTenantOperation, step
 		{Name: EnvCAPOpGlobalAccountId, Value: params.globalAccountId},
 		{Name: EnvCAPOpProviderTenantId, Value: params.providerTenantId},
 		{Name: EnvCAPOpProviderSubDomain, Value: params.providerSubdomain},
+	}
+
+	if params.providerSubaccountId != "" {
+		env = append(env, corev1.EnvVar{Name: EnvCAPOpProviderSubaccountId, Value: params.providerSubaccountId})
 	}
 
 	if stepType == v1alpha1.JobTenantOperation {

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -52,7 +52,7 @@ const (
 	AnnotationGardenerDNSTarget         = "dns.gardener.cloud/dnsnames"
 	AnnotationKubernetesDNSTarget       = "external-dns.alpha.kubernetes.io/hostname"
 	AnnotationSubscriptionContextSecret = "sme.sap.com/subscription-context-secret"
-	AnnotationProviderSubAccountId      = "sme.sap.com/provider-sub-account-id"
+	AnnotationGlobalAccountId           = "sme.sap.com/global-account-id"
 	AnnotationEnableCleanupMonitoring   = "sme.sap.com/enable-cleanup-monitoring"
 	AnnotationVSRouteRequestHeaderSet   = "sme.sap.com/vs-route-request-header-set"  // used to set the header for the vs route request
 	AnnotationVSRouteResponseHeaderSet  = "sme.sap.com/vs-route-response-header-set" // used to set the header for the vs route response
@@ -82,18 +82,19 @@ var (
 const TenantTypeProvider = "provider"
 
 const (
-	EnvCAPOpAppVersion          = "CAPOP_APP_VERSION"
-	EnvCAPOpTenantId            = "CAPOP_TENANT_ID"
-	EnvCAPOpTenantSubDomain     = "CAPOP_TENANT_SUBDOMAIN"
-	EnvCAPOpTenantOperation     = "CAPOP_TENANT_OPERATION"
-	EnvCAPOpTenantMtxsOperation = "CAPOP_TENANT_MTXS_OPERATION"
-	EnvCAPOpTenantType          = "CAPOP_TENANT_TYPE"
-	EnvCAPOpAppName             = "CAPOP_APP_NAME"
-	EnvCAPOpGlobalAccountId     = "CAPOP_GLOBAL_ACCOUNT_ID"
-	EnvCAPOpProviderTenantId    = "CAPOP_PROVIDER_TENANT_ID"
-	EnvCAPOpProviderSubDomain   = "CAPOP_PROVIDER_SUBDOMAIN"
-	EnvCAPOpSubscriptionPayload = "CAPOP_SUBSCRIPTION_PAYLOAD"
-	EnvVCAPServices             = "VCAP_SERVICES"
+	EnvCAPOpAppVersion           = "CAPOP_APP_VERSION"
+	EnvCAPOpTenantId             = "CAPOP_TENANT_ID"
+	EnvCAPOpTenantSubDomain      = "CAPOP_TENANT_SUBDOMAIN"
+	EnvCAPOpTenantOperation      = "CAPOP_TENANT_OPERATION"
+	EnvCAPOpTenantMtxsOperation  = "CAPOP_TENANT_MTXS_OPERATION"
+	EnvCAPOpTenantType           = "CAPOP_TENANT_TYPE"
+	EnvCAPOpAppName              = "CAPOP_APP_NAME"
+	EnvCAPOpGlobalAccountId      = "CAPOP_GLOBAL_ACCOUNT_ID"
+	EnvCAPOpProviderSubaccountId = "CAPOP_PROVIDER_SUBACCOUNT_ID"
+	EnvCAPOpProviderTenantId     = "CAPOP_PROVIDER_TENANT_ID"
+	EnvCAPOpProviderSubDomain    = "CAPOP_PROVIDER_SUBDOMAIN"
+	EnvCAPOpSubscriptionPayload  = "CAPOP_SUBSCRIPTION_PAYLOAD"
+	EnvVCAPServices              = "VCAP_SERVICES"
 )
 
 type JobState string

--- a/website/content/en/docs/usage/resources/captenantoperation.md
+++ b/website/content/en/docs/usage/resources/captenantoperation.md
@@ -44,7 +44,8 @@ The operation executes a series of steps (jobs) specified in or derived from the
 - `CAPOP_TENANT_SUBDOMAIN`: The subdomain (from the subaccount) of the tenant
 - `CAPOP_TENANT_TYPE`: The tenant type — `provider` or `consumer`
 - `CAPOP_APP_NAME`: The BTP app name from the corresponding `CAPApplication`
-- `CAPOP_GLOBAL_ACCOUNT_ID`: The global account identifier from the corresponding `CAPApplication`
+- `CAPOP_GLOBAL_ACCOUNT_ID`: The global account identifier from the corresponding `CAPApplication` (Deprecated: Will be removed soon).
+- `CAPOP_PROVIDER_SUBACCOUNT_ID`: The provider subaccount identifier from the corresponding `CAPApplication`
 - `CAPOP_PROVIDER_TENANT_ID`: The provider tenant identifier from the corresponding `CAPApplication`
 - `CAPOP_PROVIDER_SUBDOMAIN`: The provider tenant subdomain from the corresponding `CAPApplication`
 


### PR DESCRIPTION
 - use proper naming/case everywhere
 - deprecate old env in tenant operation (jobs) and introduce new one. (Overall update to tests to be done separately with making providerSubaccountId required)