### PR TITLE
[Misc] Reconciles: secret creation amended

### DIFF
--- a/internal/controller/informers.go
+++ b/internal/controller/informers.go
@@ -56,7 +56,7 @@ var QueueMapping map[int]map[int]string = map[int]map[int]string{
 	ResourceCAPTenantOperation:    {ResourceCAPTenantOperation: v1alpha1.CAPTenantOperationKind, ResourceCAPTenant: v1alpha1.CAPTenantKind},
 	ResourceDomain:                {ResourceDomain: v1alpha1.DomainKind},
 	ResourceClusterDomain:         {ResourceClusterDomain: v1alpha1.ClusterDomainKind},
-	ResourceSecret:                {ResourceCAPApplication: v1alpha1.CAPApplicationKind, ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind},
+	ResourceSecret:                {ResourceCAPApplication: v1alpha1.CAPApplicationKind},
 	ResourceJob:                   {ResourceCAPTenantOperation: v1alpha1.CAPTenantOperationKind, ResourceCAPApplicationVersion: v1alpha1.CAPApplicationVersionKind},
 	ResourceGateway:               {ResourceDomain: v1alpha1.DomainKind, ResourceClusterDomain: v1alpha1.ClusterDomainKind},
 	ResourceCertificate:           {ResourceDomain: v1alpha1.DomainKind, ResourceClusterDomain: v1alpha1.ClusterDomainKind},

--- a/internal/controller/reconcile-capapplicationversion.go
+++ b/internal/controller/reconcile-capapplicationversion.go
@@ -298,7 +298,7 @@ func (c *Controller) handleContentDeployJob(ca *v1alpha1.CAPApplication, cav *v1
 		ownerRef := *metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind))
 
 		// Get VCAP secret name
-		vcapSecretName, err = createVCAPSecret(jobName, cav.Namespace, ownerRef, consumedServiceInfos, c.kubeClient)
+		vcapSecretName, err = c.createVCAPSecret(jobName, cav.Namespace, ownerRef, consumedServiceInfos)
 
 		if err == nil {
 			contentDeployJob, err = c.kubeClient.BatchV1().Jobs(cav.Namespace).Create(context.TODO(), newContentDeploymentJob(cav, workload, ownerRef, vcapSecretName), metav1.CreateOptions{})
@@ -696,7 +696,7 @@ func (c *Controller) updateDeployment(ca *v1alpha1.CAPApplication, cav *v1alpha1
 		ownerRef := *metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind))
 
 		// Get VCAP secret name
-		vcapSecretName, err = createVCAPSecret(deploymentName, cav.Namespace, ownerRef, consumedServiceInfos, c.kubeClient)
+		vcapSecretName, err = c.createVCAPSecret(deploymentName, cav.Namespace, ownerRef, consumedServiceInfos)
 
 		if err == nil {
 			workloadDeployment, err = c.kubeClient.AppsV1().Deployments(cav.Namespace).Create(context.TODO(), newDeployment(ca, cav, workload, ownerRef, vcapSecretName), metav1.CreateOptions{})

--- a/internal/controller/reconcile-captenantoperation.go
+++ b/internal/controller/reconcile-captenantoperation.go
@@ -402,7 +402,7 @@ func (c *Controller) initiateJobForCAPTenantOperationStep(ctx context.Context, c
 
 	// create VCAP secret from consumed BTP services
 	consumedServiceInfos := getConsumedServiceInfos(getConsumedServiceMap(workload.ConsumedBTPServices), relatedResources.CAPApplication.Spec.BTP.Services)
-	vcapSecretName, err := createVCAPSecret(ctop.Name+"-"+strings.ToLower(workload.Name), ctop.Namespace, *metav1.NewControllerRef(ctop, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPTenantOperationKind)), consumedServiceInfos, c.kubeClient)
+	vcapSecretName, err := c.createVCAPSecret(ctop.Name+"-"+strings.ToLower(workload.Name), ctop.Namespace, *metav1.NewControllerRef(ctop, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPTenantOperationKind)), consumedServiceInfos)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -22,7 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
-	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/informers"
 	"k8s.io/klog/v2"
 )
 
@@ -44,6 +44,7 @@ const (
 	LabelExposedWorkload                = "sme.sap.com/exposed-workload"
 	LabelDNSNameHash                    = "sme.sap.com/dns-name-hash"
 	LabelSubscriptionGUID               = "sme.sap.com/subscription-guid"
+	LabelSecretOwnerHash                = "sme.sap.com/secret-owner-hash"
 	AnnotationOwnerIdentifier           = "sme.sap.com/owner-identifier"
 	AnnotationBTPApplicationIdentifier  = "sme.sap.com/btp-app-identifier"
 	AnnotationAppId                     = "sme.sap.com/app-identifier"
@@ -394,10 +395,10 @@ func getConsumedServiceInfos(consumedServicesMap map[string]string, serviceInfos
 	return consumedServiceInfo
 }
 
-func generateVCAPEnv(ns string, serviceInfos []v1alpha1.ServiceInfo, kubeClient kubernetes.Interface) ([]byte, error) {
+func generateVCAPEnv(ns string, serviceInfos []v1alpha1.ServiceInfo, kubeInformerFactory informers.SharedInformerFactory) ([]byte, error) {
 	envVCAPServices := map[string][]map[string]any{}
 	for _, serviceInfo := range serviceInfos {
-		entry, err := util.CreateVCAPEntryFromSecret(&serviceInfo, ns, kubeClient)
+		entry, err := util.CreateVCAPEntryFromSecret(&serviceInfo, ns, nil, kubeInformerFactory)
 		if err != nil {
 			return nil, err
 		}
@@ -414,19 +415,32 @@ func generateVCAPEnv(ns string, serviceInfos []v1alpha1.ServiceInfo, kubeClient 
 	return json.Marshal(envVCAPServices)
 }
 
-func createVCAPSecret(namePrefix string, ns string, ownerRef metav1.OwnerReference, serviceInfos []v1alpha1.ServiceInfo, kubeClient kubernetes.Interface) (string, error) {
+func (c Controller) createVCAPSecret(namePrefix string, ns string, ownerRef metav1.OwnerReference, serviceInfos []v1alpha1.ServiceInfo) (string, error) {
 	// Generate VCAP_SERVICES env. variable
-	vcapEnv, err := generateVCAPEnv(ns, serviceInfos, kubeClient)
+	vcapEnv, err := generateVCAPEnv(ns, serviceInfos, c.kubeInformerFactory)
 	if err != nil {
 		return "", err
 	}
 
+	secretLabels := map[string]string{
+		LabelSecretOwnerHash: sha1Sum(ns, ownerRef.Name, namePrefix),
+	}
+
+	secretList, err := c.kubeInformerFactory.Core().V1().Secrets().Lister().Secrets(ns).List(labels.SelectorFromSet(secretLabels))
+	if err != nil { // Some error occurred
+		return "", err
+	} else if len(secretList) > 0 { // Existing secret present
+		return secretList[0].Name, nil
+	}
+
+	// Nothing Found -->
 	// Create a secret for VCAP_SERVICES for the given workload
-	secret, err := kubeClient.CoreV1().Secrets(ns).Create(context.TODO(),
+	secret, err := c.kubeClient.CoreV1().Secrets(ns).Create(context.TODO(),
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{
 				GenerateName:    namePrefix + "-",
 				OwnerReferences: []metav1.OwnerReference{ownerRef},
+				Labels:          secretLabels,
 			},
 			StringData: map[string]string{
 				EnvVCAPServices: string(vcapEnv),
@@ -438,7 +452,6 @@ func createVCAPSecret(namePrefix string, ns string, ownerRef metav1.OwnerReferen
 		return "", err
 	}
 	// Successfully created deployment secret --> return name
-	// @TODO: Reconcile CAV once we expect secrets/credentials to be updated
 	return secret.Name, nil
 }
 

--- a/internal/util/vcap-credentials.go
+++ b/internal/util/vcap-credentials.go
@@ -11,7 +11,9 @@ import (
 	"fmt"
 
 	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
 )
 
@@ -65,7 +67,7 @@ const (
 )
 
 func ReadServiceCredentialsFromSecret[T any](serviceInfo *v1alpha1.ServiceInfo, ns string, kubeClient kubernetes.Interface) (*T, error) {
-	entry, err := CreateVCAPEntryFromSecret(serviceInfo, ns, kubeClient)
+	entry, err := CreateVCAPEntryFromSecret(serviceInfo, ns, kubeClient, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -76,9 +78,15 @@ func ReadServiceCredentialsFromSecret[T any](serviceInfo *v1alpha1.ServiceInfo, 
 	return ParseJSON[T](b)
 }
 
-func CreateVCAPEntryFromSecret(serviceInfo *v1alpha1.ServiceInfo, ns string, kubeClient kubernetes.Interface) (entry map[string]any, err error) {
+func CreateVCAPEntryFromSecret(serviceInfo *v1alpha1.ServiceInfo, ns string, kubeClient kubernetes.Interface, kubeInformerFactory informers.SharedInformerFactory) (entry map[string]any, err error) {
+	var secret *corev1.Secret
 	// Get secret
-	secret, err := kubeClient.CoreV1().Secrets(ns).Get(context.TODO(), serviceInfo.Secret, metav1.GetOptions{})
+	if kubeInformerFactory != nil {
+		secret, err = kubeInformerFactory.Core().V1().Secrets().Lister().Secrets(ns).Get(serviceInfo.Secret)
+	} else {
+		secret, err = kubeClient.CoreV1().Secrets(ns).Get(context.TODO(), serviceInfo.Secret, metav1.GetOptions{})
+	}
+
 	if err != nil {
 		return nil, err
 	}

--- a/internal/util/vcap-credentials_test.go
+++ b/internal/util/vcap-credentials_test.go
@@ -10,15 +10,17 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	k8sruntime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes/fake"
 )
 
-func createTestClient() (*fake.Clientset, error) {
+func createTestClient(kubeInformerFactory informers.SharedInformerFactory) (*fake.Clientset, error) {
 	secs := []k8sruntime.Object{
 		&corev1.Secret{
 			ObjectMeta: metav1.ObjectMeta{Name: "no-meta-credential-key", Namespace: "default"},
@@ -101,6 +103,11 @@ func createTestClient() (*fake.Clientset, error) {
 			},
 		},
 	}
+	if kubeInformerFactory != nil {
+		for _, sec := range secs {
+			kubeInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(sec)
+		}
+	}
 	return fake.NewSimpleClientset(secs...), nil
 }
 
@@ -128,7 +135,7 @@ func testCreateVCAPEntryFromSecret(t *testing.T) {
 			namespace:   "another",
 			serviceInfo: &v1alpha1.ServiceInfo{Name: "service-a", Secret: "no-meta-credential-key", Class: "xzy"},
 			expectError: true,
-			errorMsg:    "secrets \"no-meta-credential-key\" not found",
+			errorMsg:    "secret \"no-meta-credential-key\" not found",
 		},
 		{
 			name:                 "valid credentials (container) with metadata",
@@ -153,17 +160,18 @@ func testCreateVCAPEntryFromSecret(t *testing.T) {
 			expectTags:           true,
 		},
 	}
-	c, _ := createTestClient()
+	kubeInformerFactory := informers.NewSharedInformerFactory(fake.NewSimpleClientset(), 30*time.Minute)
+	c, _ := createTestClient(kubeInformerFactory)
 	for i := range cases {
 		t.Run(cases[i].name, func(t *testing.T) {
 			config := &cases[i]
-			entry, err := CreateVCAPEntryFromSecret(config.serviceInfo, config.namespace, c)
+			entry, err := CreateVCAPEntryFromSecret(config.serviceInfo, config.namespace, c, kubeInformerFactory)
 			if err != nil {
 				if !config.expectError {
 					t.Errorf("unexpected error in test case: %s", config.name)
 				}
 				if config.errorMsg != "" && err.Error() != config.errorMsg {
-					t.Errorf("error differs from expected for test case: %s", config.name)
+					t.Errorf("error '%s' differs from expected for test case: %s", err.Error(), config.name)
 				}
 				return
 			} else {
@@ -182,7 +190,7 @@ func testCreateVCAPEntryFromSecret(t *testing.T) {
 }
 
 func testReadServiceCredentialsFromSecret(t *testing.T) {
-	c, _ := createTestClient()
+	c, _ := createTestClient(nil)
 
 	// test successful read
 	secretName := "metadata-with-credential-key"


### PR DESCRIPTION
There may be unhandled errors due invalid workload spec during resource creation, which lead (in rare situations) to unbound creation and reconciliation of secrets. With this change, we ensure that:
- there is no unnecessary reconcile of CAVs based on secret creation
- also, we ensure that workload secrets are verified for existence before creation This addresses potential errors during resource creation(e.g. deployments), due to invalid spec.

Resolves: #402