### PR TITLE
[Feat] Operator: Rollout on Credential Update Enabled

### DIFF
--- a/crds/sme.sap.com_capapplications.yaml
+++ b/crds/sme.sap.com_capapplications.yaml
@@ -120,6 +120,8 @@ spec:
                 type: object
               providerSubaccountId:
                 type: string
+              rolloutOnCredentialUpdate:
+                type: boolean
             required:
             - btp
             - btpAppName

--- a/internal/controller/controller.go
+++ b/internal/controller/controller.go
@@ -55,6 +55,7 @@ type Controller struct {
 	queues                       map[int]workqueue.TypedRateLimitingInterface[QueueItem]
 	eventBroadcaster             events.EventBroadcaster
 	eventRecorder                events.EventRecorder
+	rolloutManager               *rolloutManager
 }
 
 var (
@@ -138,6 +139,7 @@ func NewController(client kubernetes.Interface, crdClient versioned.Interface, i
 		eventBroadcaster:             eventBroadcaster,
 		eventRecorder:                recorder,
 	}
+	c.rolloutManager = newRolloutManager(c)
 	return c
 }
 
@@ -231,6 +233,11 @@ func (c *Controller) Start(ctx context.Context) {
 	// start version cleanup routines
 	wg.Go(func() {
 		c.startVersionCleanup(qCxt)
+	})
+
+	// start rollout manager
+	wg.Go(func() {
+		c.rolloutManager.Start(qCxt)
 	})
 
 	// wait for workers

--- a/internal/controller/controller_test.go
+++ b/internal/controller/controller_test.go
@@ -99,6 +99,8 @@ func TestController_processQueue(t *testing.T) {
 				eventRecorder:               events.NewFakeRecorder(10),
 			}
 
+			testC.rolloutManager = newRolloutManager(testC)
+
 			// Create a background context that gets cancelled once the test run completes
 			ctx, cancel := context.WithCancel(context.Background())
 			cancel()

--- a/internal/controller/informers.go
+++ b/internal/controller/informers.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/client-go/tools/cache"
 	"k8s.io/klog/v2"
 )
@@ -164,7 +165,7 @@ func (c *Controller) registerDestinationRuleListeners() {
 
 func (c *Controller) registerSecretListeners() {
 	c.kubeInformerFactory.Core().V1().Secrets().Informer().
-		AddEventHandler(c.getEventHandlerFuncsForResource(ResourceSecret))
+		AddEventHandler(c.getSecretEventHandlerFuncs())
 }
 
 func (c *Controller) registerGatewayListeners() {
@@ -185,6 +186,30 @@ func (c *Controller) registerCertManagerCertificateListeners() {
 func (c *Controller) registerGardenerDNSEntrytListeners() {
 	c.gardenerDNSInformerFactory.Dns().V1alpha1().DNSEntries().Informer().
 		AddEventHandler(c.getEventHandlerFuncsForResource(ResourceDNSEntry))
+}
+
+func (c *Controller) getSecretEventHandlerFuncs() cache.ResourceEventHandlerFuncs {
+	return cache.ResourceEventHandlerFuncs{
+		UpdateFunc: func(oldObj, newObj any) {
+			new, newOk := getMetaObject(newObj)
+			old, oldOk := getMetaObject(oldObj)
+			if !newOk || !oldOk || old.GetResourceVersion() == new.GetResourceVersion() {
+				return // no relevant changes
+			}
+			secretNS := new.GetNamespace()
+			cas, err := c.crdInformerFactory.Sme().V1alpha1().CAPApplications().Lister().CAPApplications(secretNS).List(labels.Everything())
+			if err != nil {
+				klog.ErrorS(err, "error retrieving applications", "informers", "rollout-manager")
+			}
+
+			for _, ca := range cas {
+				if ca.Spec.RolloutOnCredentialUpdate {
+					c.rolloutManager.Enqueue(secretNS, new.GetName())
+					break // one enqueue per namespace per secret is enough
+				}
+			}
+		},
+	}
 }
 
 func (c *Controller) enqueueModifiedResource(sourceKey int, new, old any) {

--- a/internal/controller/informers_test.go
+++ b/internal/controller/informers_test.go
@@ -15,6 +15,27 @@ import (
 	"k8s.io/client-go/util/workqueue"
 )
 
+// secretHandlerFixture builds a controller with the given CAPApplications pre-loaded
+// and attaches a real rolloutManager so the handler can enqueue into it.
+func secretHandlerFixture(cas []*v1alpha1.CAPApplication) *Controller {
+	c := getTestController(testResources{cas: cas})
+	c.rolloutManager = newRolloutManager(c)
+	return c
+}
+
+// pendingForNamespace reads the accumulated pending secrets without consuming them.
+func pendingForNamespace(m *rolloutManager, ns string) map[string]struct{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.pendingSecrets[ns]
+}
+
+func secretV(name, ns, rv string) *corev1.Secret {
+	return &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: ns, ResourceVersion: rv},
+	}
+}
+
 var expectedResult = false
 
 type dummyType struct {
@@ -158,5 +179,159 @@ func TestController_initializeInformers(t *testing.T) {
 				t.Error("Unexpected result", expectedResult)
 			}
 		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getSecretEventHandlerFuncs
+// ---------------------------------------------------------------------------
+
+// TestSecretHandler_SameResourceVersion verifies that an update where old and new
+// have identical ResourceVersions is ignored (no enqueue).
+func TestSecretHandler_SameResourceVersion(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	c := secretHandlerFixture([]*v1alpha1.CAPApplication{ca})
+
+	handler := c.getSecretEventHandlerFuncs()
+	old := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "1")
+	new := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "1") // same RV
+
+	handler.UpdateFunc(old, new)
+
+	if got := pendingForNamespace(c.rolloutManager, metav1.NamespaceDefault); len(got) != 0 {
+		t.Errorf("expected nothing enqueued for same ResourceVersion, got %v", got)
+	}
+}
+
+// TestSecretHandler_InvalidObjects verifies that non-meta objects are silently ignored.
+func TestSecretHandler_InvalidObjects(t *testing.T) {
+	defer deregisterMetrics()
+	c := secretHandlerFixture(nil)
+
+	handler := c.getSecretEventHandlerFuncs()
+	// plain strings cannot be accessed via meta.Accessor
+	handler.UpdateFunc("not-a-k8s-object", "also-not-a-k8s-object")
+
+	if got := pendingForNamespace(c.rolloutManager, metav1.NamespaceDefault); len(got) != 0 {
+		t.Errorf("expected nothing enqueued for non-meta objects, got %v", got)
+	}
+}
+
+// TestSecretHandler_NoCAPApplicationsInNamespace verifies that when no
+// CAPApplication exists in the secret's namespace, nothing is enqueued.
+func TestSecretHandler_NoCAPApplicationsInNamespace(t *testing.T) {
+	defer deregisterMetrics()
+	c := secretHandlerFixture(nil) // no CAs
+
+	handler := c.getSecretEventHandlerFuncs()
+	old := secretV("some-secret", metav1.NamespaceDefault, "1")
+	new := secretV("some-secret", metav1.NamespaceDefault, "2")
+
+	handler.UpdateFunc(old, new)
+
+	if got := pendingForNamespace(c.rolloutManager, metav1.NamespaceDefault); len(got) != 0 {
+		t.Errorf("expected nothing enqueued when no CAPApplications exist, got %v", got)
+	}
+}
+
+// TestSecretHandler_AllCAsRolloutDisabled verifies that when every CAPApplication
+// in the namespace has RolloutOnCredentialUpdate=false, nothing is enqueued.
+func TestSecretHandler_AllCAsRolloutDisabled(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", false /* disabled */, btpServices())
+	c := secretHandlerFixture([]*v1alpha1.CAPApplication{ca})
+
+	handler := c.getSecretEventHandlerFuncs()
+	old := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "1")
+	new := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "2")
+
+	handler.UpdateFunc(old, new)
+
+	if got := pendingForNamespace(c.rolloutManager, metav1.NamespaceDefault); len(got) != 0 {
+		t.Errorf("expected nothing enqueued when all CAs have rollout disabled, got %v", got)
+	}
+}
+
+// TestSecretHandler_OneCAWithRolloutEnabled verifies that a secret update enqueues
+// exactly once when at least one CAPApplication in the namespace has
+// RolloutOnCredentialUpdate=true, regardless of how many CAs exist.
+func TestSecretHandler_OneCAWithRolloutEnabled(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	c := secretHandlerFixture([]*v1alpha1.CAPApplication{ca})
+
+	handler := c.getSecretEventHandlerFuncs()
+	old := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "1")
+	new := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "2")
+
+	handler.UpdateFunc(old, new)
+
+	got := pendingForNamespace(c.rolloutManager, metav1.NamespaceDefault)
+	if len(got) != 1 {
+		t.Fatalf("expected 1 pending secret, got %d: %v", len(got), got)
+	}
+	if _, ok := got["cap-cap-01-uaa-bind-cf"]; !ok {
+		t.Errorf("expected secret name cap-cap-01-uaa-bind-cf to be pending, got %v", got)
+	}
+}
+
+// TestSecretHandler_EnqueuesOnceWithMixedCAs verifies that even when one CA has
+// rollout disabled and another has it enabled, the secret is enqueued exactly once
+// (the handler breaks after the first CA that triggers the enqueue).
+func TestSecretHandler_EnqueuesOnceWithMixedCAs(t *testing.T) {
+	defer deregisterMetrics()
+	caDisabled := buildCA("test-cap-disabled", false, btpServices())
+	caEnabled := buildCA("test-cap-enabled", true, btpServices())
+	c := secretHandlerFixture([]*v1alpha1.CAPApplication{caDisabled, caEnabled})
+
+	handler := c.getSecretEventHandlerFuncs()
+	old := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "1")
+	new := secretV("cap-cap-01-uaa-bind-cf", metav1.NamespaceDefault, "2")
+
+	handler.UpdateFunc(old, new)
+	handler.UpdateFunc(old, new) // second update with same secret, different call
+
+	got := pendingForNamespace(c.rolloutManager, metav1.NamespaceDefault)
+	// pendingSecrets is a set so duplicate enqueues for the same secret name are idempotent
+	if len(got) != 1 {
+		t.Fatalf("expected 1 pending secret entry, got %d: %v", len(got), got)
+	}
+}
+
+// TestSecretHandler_OnlyUpdateFuncWired verifies that the Add and Delete handler
+// slots are nil — the secret handler intentionally only reacts to updates.
+func TestSecretHandler_OnlyUpdateFuncWired(t *testing.T) {
+	defer deregisterMetrics()
+	c := secretHandlerFixture(nil)
+	handler := c.getSecretEventHandlerFuncs()
+
+	if handler.AddFunc != nil {
+		t.Error("expected AddFunc to be nil for secret handler")
+	}
+	if handler.DeleteFunc != nil {
+		t.Error("expected DeleteFunc to be nil for secret handler")
+	}
+	if handler.UpdateFunc == nil {
+		t.Error("expected UpdateFunc to be set for secret handler")
+	}
+}
+
+// TestSecretHandler_MultipleDistinctSecrets verifies that several different secrets
+// updated in the same namespace all accumulate in pendingSecrets as a set.
+func TestSecretHandler_MultipleDistinctSecrets(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	c := secretHandlerFixture([]*v1alpha1.CAPApplication{ca})
+
+	handler := c.getSecretEventHandlerFuncs()
+	for i, name := range []string{"secret-a", "secret-b", "secret-c"} {
+		rv := func(n int) string { return string(rune('0' + n)) }
+		handler.UpdateFunc(secretV(name, metav1.NamespaceDefault, rv(i)), secretV(name, metav1.NamespaceDefault, rv(i+10)))
+	}
+
+	got := pendingForNamespace(c.rolloutManager, metav1.NamespaceDefault)
+	if len(got) != 3 {
+		t.Fatalf("expected 3 pending secrets, got %d: %v", len(got), got)
 	}
 }

--- a/internal/controller/reconcile.go
+++ b/internal/controller/reconcile.go
@@ -406,22 +406,29 @@ func generateVCAPEnv(ns string, serviceInfos []v1alpha1.ServiceInfo, kubeInforme
 	return json.Marshal(envVCAPServices)
 }
 
-func (c Controller) createVCAPSecret(namePrefix string, ns string, ownerRef metav1.OwnerReference, serviceInfos []v1alpha1.ServiceInfo) (string, error) {
+func (c *Controller) createVCAPSecret(namePrefix string, ns string, ownerRef metav1.OwnerReference, serviceInfos []v1alpha1.ServiceInfo) (string, error) {
 	// Generate VCAP_SERVICES env. variable
 	vcapEnv, err := generateVCAPEnv(ns, serviceInfos, c.kubeInformerFactory)
 	if err != nil {
 		return "", err
 	}
 
+	return c.createSecretFromVCAPEnv(ns, ownerRef, namePrefix, vcapEnv, false)
+}
+
+func (c *Controller) createSecretFromVCAPEnv(ns string, ownerRef metav1.OwnerReference, namePrefix string, vcapEnv []byte, skipExistingCheck bool) (string, error) {
 	secretLabels := map[string]string{
 		LabelSecretOwnerHash: sha1Sum(ns, ownerRef.Name, namePrefix),
 	}
 
-	secretList, err := c.kubeInformerFactory.Core().V1().Secrets().Lister().Secrets(ns).List(labels.SelectorFromSet(secretLabels))
-	if err != nil { // Some error occurred
-		return "", err
-	} else if len(secretList) > 0 { // Existing secret present
-		return secretList[0].Name, nil
+	// During rolloutOnCredentialUpdate the existing secret check may be skipped
+	if !skipExistingCheck {
+		secretList, err := c.kubeInformerFactory.Core().V1().Secrets().Lister().Secrets(ns).List(labels.SelectorFromSet(secretLabels))
+		if err != nil { // Some error occurred
+			return "", err
+		} else if len(secretList) > 0 { // Existing secret present
+			return secretList[0].Name, nil
+		}
 	}
 
 	// Nothing Found -->

--- a/internal/controller/rollout-manager.go
+++ b/internal/controller/rollout-manager.go
@@ -1,0 +1,386 @@
+/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/sap/cap-operator/internal/util"
+	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/util/workqueue"
+	"k8s.io/klog/v2"
+)
+
+const (
+	EnvRolloutDelay     = "ROLLOUT_DELAY"
+	defaultRolloutDelay = time.Hour
+	minRolloutDelay     = 30 * time.Second
+)
+
+// getRolloutDelay returns the rollout delay from the ROLLOUT_DELAY env var.
+// Falls back to defaultRolloutDelay if unset or unparseable.
+// Values below minRolloutDelay are clamped to minRolloutDelay.
+func getRolloutDelay() time.Duration {
+	if v, ok := os.LookupEnv(EnvRolloutDelay); ok {
+		dur, err := time.ParseDuration(strings.TrimSpace(v))
+		if err != nil {
+			klog.ErrorS(nil, "Invalid ROLLOUT_DELAY value; using default", "value", v, "default", defaultRolloutDelay)
+			return defaultRolloutDelay
+		}
+		if dur < minRolloutDelay {
+			klog.ErrorS(nil, "ROLLOUT_DELAY below minimum; using minimum", "value", dur, "minimum", minRolloutDelay)
+			return minRolloutDelay
+		}
+		return dur
+	}
+	return defaultRolloutDelay
+}
+
+// rolloutManager batches credential-rotation work per namespace.
+// The informer calls Enqueue(namespace, secretName) for every changed BTP service secret.
+// Items are placed on the delaying queue with a rolloutDelay (default 1-hour) window;
+// multiple Enqueue calls within this window for the same namespace are collected and
+// processed once by the queue by accumulating all secret names in pendingSecrets.
+// When the queue item reconciles, only workloads that consume the service affected by
+// one of those secrets are rolled out.
+type rolloutManager struct {
+	queue          workqueue.TypedRateLimitingInterface[string]
+	ctrl           *Controller
+	mu             sync.Mutex
+	pendingSecrets map[string]map[string]struct{} // namespace -> set of secret names
+	rolloutDelay   time.Duration
+}
+
+func newRolloutManager(ctrl *Controller) *rolloutManager {
+	return &rolloutManager{
+		queue: workqueue.NewTypedRateLimitingQueueWithConfig(
+			workqueue.DefaultTypedControllerRateLimiter[string](),
+			workqueue.TypedRateLimitingQueueConfig[string]{Name: "rollout-manager"},
+		),
+		ctrl:           ctrl,
+		pendingSecrets: map[string]map[string]struct{}{},
+		rolloutDelay:   getRolloutDelay(),
+	}
+}
+
+// records secretName as pending for namespace and schedules a delayed rollout pass.
+// Duplicate namespaces within the delay window are collected to be processed once by the queue.
+func (m *rolloutManager) Enqueue(namespace, secretName string) {
+	m.mu.Lock()
+	if m.pendingSecrets[namespace] == nil {
+		m.pendingSecrets[namespace] = map[string]struct{}{}
+	}
+	m.pendingSecrets[namespace][secretName] = struct{}{}
+	m.mu.Unlock()
+
+	m.queue.AddAfter(namespace, m.rolloutDelay)
+}
+
+// atomically removes and returns the accumulated secret names for the given namespace
+func (m *rolloutManager) drainSecrets(namespace string) map[string]struct{} {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	secrets := m.pendingSecrets[namespace]
+	delete(m.pendingSecrets, namespace)
+	return secrets
+}
+
+// merges secrets back into pendingSecrets so a re-queued item still has data to process
+func (m *rolloutManager) restoreSecrets(namespace string, secrets map[string]struct{}) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.pendingSecrets[namespace] == nil {
+		m.pendingSecrets[namespace] = map[string]struct{}{}
+	}
+	for s := range secrets {
+		m.pendingSecrets[namespace][s] = struct{}{}
+	}
+}
+
+func (m *rolloutManager) Start(ctx context.Context) {
+	go func() {
+		<-ctx.Done()
+		m.queue.ShutDown()
+	}()
+
+	concurrency := getConcurrencyForResource(ResourceCAPApplicationVersion)
+	klog.InfoS("starting rollout manager", "concurrency", concurrency)
+
+	var wg sync.WaitGroup
+	for range concurrency {
+		wg.Go(func() {
+			for {
+				ns, shutdown := m.queue.Get()
+				if shutdown {
+					return
+				}
+				affectedSecrets := m.drainSecrets(ns)
+				klog.InfoS("processing credential rotation", "namespace", ns, "secrets", len(affectedSecrets))
+				if err := m.processNamespace(ctx, ns, affectedSecrets); err != nil {
+					util.LogError(err, "error processing credential rotation", "processNamespace", nil, nil, "namespace", ns)
+					m.restoreSecrets(ns, affectedSecrets)
+					m.queue.AddRateLimited(ns)
+				} else {
+					m.queue.Forget(ns)
+				}
+				m.queue.Done(ns)
+			}
+		})
+	}
+
+	// On startup, enqueue namespace/secrets from all relevant CAs, to potentially cover missed updates during a crash.
+	if err := m.enqueuePendingRollouts(); err != nil {
+		util.LogError(err, "error during startup rollout check", "rolloutManager", nil, nil)
+	}
+
+	wg.Wait()
+	klog.InfoS("rollout manager stopped")
+}
+
+// enqueue namespace/secrets from all relevant CAs (RolloutOnCredentialUpdate=true), to potentially handle missed updates (e.g. during a crash)
+func (m *rolloutManager) enqueuePendingRollouts() error {
+	cas, err := m.ctrl.crdInformerFactory.Sme().V1alpha1().CAPApplications().Lister().List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("error listing CAPApplications for startup rollout check: %w", err)
+	}
+
+	// namespace -> set of secret names referenced by relevant CAs
+	pending := map[string]map[string]struct{}{}
+	for _, ca := range cas {
+		if !ca.Spec.RolloutOnCredentialUpdate {
+			continue
+		}
+		ns := ca.Namespace
+		if pending[ns] == nil {
+			pending[ns] = map[string]struct{}{}
+		}
+		for _, svc := range ca.Spec.BTP.Services {
+			pending[ns][svc.Secret] = struct{}{}
+		}
+	}
+
+	for ns, secrets := range pending {
+		m.restoreSecrets(ns, secrets)
+		m.queue.AddAfter(ns, m.rolloutDelay)
+		klog.InfoS("startup rollout check: enqueued namespace", "namespace", ns, "secrets", len(secrets))
+	}
+	return nil
+}
+
+// rolls out affected deployments for all CAPApplications in the namespace that have RolloutOnCredentialUpdate enabled.
+func (m *rolloutManager) processNamespace(ctx context.Context, namespace string, affectedSecrets map[string]struct{}) error {
+	if len(affectedSecrets) == 0 {
+		klog.InfoS("no affected secrets exist for this namespace. Skipping rollout..", "namespace", namespace)
+		return nil
+	}
+
+	cas, err := m.ctrl.crdInformerFactory.Sme().V1alpha1().CAPApplications().Lister().CAPApplications(namespace).List(labels.Everything())
+	if err != nil {
+		return fmt.Errorf("error listing CAPApplications in namespace %s: %w", namespace, err)
+	}
+	for _, ca := range cas {
+		if !ca.Spec.RolloutOnCredentialUpdate {
+			continue
+		}
+		affectedServiceNames := btpServicesForSecrets(ca, affectedSecrets)
+		if len(affectedServiceNames) == 0 {
+			continue
+		}
+		if err := m.processAffectedApplication(ctx, ca, affectedServiceNames); err != nil {
+			util.LogError(err, "error rolling out application for credential update", "controller", ca, nil, "application", ca.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// returns the set of BTP service names in the CA that refer to the provided affected secrets.
+func btpServicesForSecrets(ca *v1alpha1.CAPApplication, affectedSecrets map[string]struct{}) map[string]struct{} {
+	result := map[string]struct{}{}
+	for _, serviceInfo := range ca.Spec.BTP.Services {
+		if _, ok := affectedSecrets[serviceInfo.Secret]; ok {
+			result[serviceInfo.Name] = struct{}{}
+		}
+	}
+	return result
+}
+
+// triggers processing of all relevant CAVs for the CA
+func (m *rolloutManager) processAffectedApplication(ctx context.Context, ca *v1alpha1.CAPApplication, affectedServiceNames map[string]struct{}) error {
+	relevantCAVs, err := m.ctrl.collectRelevantCAVs(ca)
+	if err != nil {
+		return fmt.Errorf("error collecting CAVs for %s: %w", ca.Name, err)
+	}
+	for _, cav := range relevantCAVs {
+		if err := m.processAffectedVersion(ctx, ca, cav, affectedServiceNames); err != nil {
+			util.LogError(err, "error rolling out CAV for credential update", "processAffectedApplication", cav, nil, "application", ca.Name, "version", cav.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// collects all affected deployment workloads and rolls out those that consume at least one of the affected BTP services.
+func (m *rolloutManager) processAffectedVersion(ctx context.Context, ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion, affectedServiceNames map[string]struct{}) error {
+	ownerRef := *metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind))
+	for i := range cav.Spec.Workloads {
+		workload := &cav.Spec.Workloads[i]
+		if workload.DeploymentDefinition == nil || !workloadConsumesAffectedService(workload, affectedServiceNames) {
+			continue
+		}
+		if err := m.ctrl.rolloutWorkloadDeployment(ctx, ca, cav, workload, ownerRef); err != nil {
+			util.LogError(err, "error rolling out workload deployment for credential update", "processAffectedVersion", cav, nil, "workload", workload.Name)
+			return err
+		}
+	}
+	return nil
+}
+
+// reports whether the workload consumes any service from affectedServiceNames
+func workloadConsumesAffectedService(workload *v1alpha1.WorkloadDetails, affectedServiceNames map[string]struct{}) bool {
+	for _, svcName := range workload.ConsumedBTPServices {
+		if _, ok := affectedServiceNames[svcName]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// returns the latest ready CAV plus all ready CAVs currently in use by tenants.
+func (c *Controller) collectRelevantCAVs(ca *v1alpha1.CAPApplication) (map[string]*v1alpha1.CAPApplicationVersion, error) {
+	relevantCAVs := map[string]*v1alpha1.CAPApplicationVersion{}
+
+	latestCav, err := c.getLatestReadyCAPApplicationVersion(ca, true)
+	if err != nil {
+		return nil, err
+	}
+	if latestCav != nil {
+		relevantCAVs[latestCav.Name] = latestCav
+	}
+
+	if err = c.addTenantCAVs(ca, relevantCAVs); err != nil {
+		return nil, err
+	}
+	return relevantCAVs, nil
+}
+
+// appends all ready CAVs referenced by ready tenants of the CA into the provided map.
+func (c *Controller) addTenantCAVs(ca *v1alpha1.CAPApplication, relevantCAVs map[string]*v1alpha1.CAPApplicationVersion) error {
+	tenants, err := c.getRelevantTenantsForCA(ca)
+	if err != nil {
+		return err
+	}
+	for _, tenant := range tenants {
+		if tenant.Status.State != v1alpha1.CAPTenantStateReady || tenant.Status.CurrentCAPApplicationVersionInstance == "" {
+			continue
+		}
+		cavName := tenant.Status.CurrentCAPApplicationVersionInstance
+		if _, seen := relevantCAVs[cavName]; seen {
+			continue
+		}
+		cav, err := c.crdInformerFactory.Sme().V1alpha1().CAPApplicationVersions().Lister().CAPApplicationVersions(ca.Namespace).Get(cavName)
+		if err != nil {
+			util.LogError(err, "error getting CAPApplicationVersion for credential rollout", "controller", ca, nil, "application", ca.Name, "version", cavName)
+			continue
+		}
+		if isCROConditionReady(cav.Status.GenericStatus) {
+			relevantCAVs[cav.Name] = cav
+		}
+	}
+	return nil
+}
+
+// rotates the VCAP secret used by the affected deployment workload and updates the deployment's envFrom reference to trigger a
+// Kubernetes rollout with fresh credentials.
+func (c *Controller) rolloutWorkloadDeployment(ctx context.Context, ca *v1alpha1.CAPApplication, cav *v1alpha1.CAPApplicationVersion, workload *v1alpha1.WorkloadDetails, ownerRef metav1.OwnerReference) error {
+	deploymentName := getWorkloadName(cav.Name, workload.Name)
+
+	deployment, err := c.kubeClient.AppsV1().Deployments(cav.Namespace).Get(ctx, deploymentName, metav1.GetOptions{})
+	if k8sErrors.IsNotFound(err) {
+		return nil // not yet created, nothing to roll out
+	}
+	if err != nil {
+		return fmt.Errorf("error getting deployment %s for credential rollout: %w", deploymentName, err)
+	}
+	consumedServiceInfos := getConsumedServiceInfos(getConsumedServiceMap(workload.ConsumedBTPServices), ca.Spec.BTP.Services)
+	vcapEnv, err := generateVCAPEnv(cav.Namespace, consumedServiceInfos, c.kubeInformerFactory)
+	if err != nil {
+		return err
+	}
+
+	unchanged, err := c.checkVCAPSecret(ctx, cav.Namespace, deploymentName, ownerRef, vcapEnv)
+	if err != nil {
+		return err
+	}
+	if unchanged {
+		klog.InfoS("VCAP_SERVICES content unchanged, skipping rollout", "deployment", deploymentName)
+		return nil
+	}
+
+	newVCAPSecretName, err := c.createSecretFromVCAPEnv(cav.Namespace, ownerRef, deploymentName, vcapEnv, true)
+	if err != nil {
+		return fmt.Errorf("error creating new VCAP secret for deployment %s: %w", deploymentName, err)
+	}
+
+	if err = c.updateDeploymentVCAPRef(ctx, cav.Namespace, deployment, newVCAPSecretName); err != nil {
+		return err
+	}
+
+	util.LogInfo("Deployment updated for credential rollout", string(Ready), cav,
+		&appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: deploymentName, Namespace: cav.Namespace}},
+		"deployment", deploymentName, "vcapSecret", newVCAPSecretName)
+	return nil
+}
+
+// deletes the existing VCAP secret for the deployment so createVCAPSecret will regenerate it with fresh credential data.
+func (c *Controller) checkVCAPSecret(ctx context.Context, namespace, deploymentName string, ownerRef metav1.OwnerReference, vcapEnv []byte) (bool, error) {
+	validVCAPExists := false
+	secretSelector := labels.SelectorFromSet(map[string]string{
+		LabelSecretOwnerHash: sha1Sum(namespace, ownerRef.Name, deploymentName),
+	})
+	existingSecrets, err := c.kubeInformerFactory.Core().V1().Secrets().Lister().Secrets(namespace).List(secretSelector)
+	if err != nil {
+		return validVCAPExists, fmt.Errorf("error listing VCAP secrets for deployment %s: %w", deploymentName, err)
+	}
+
+	for _, s := range existingSecrets {
+		if bytes.Equal(s.Data[EnvVCAPServices], vcapEnv) {
+			validVCAPExists = true
+			continue
+		}
+		if delErr := c.kubeClient.CoreV1().Secrets(namespace).Delete(ctx, s.Name, metav1.DeleteOptions{}); delErr != nil && !k8sErrors.IsNotFound(delErr) {
+			return validVCAPExists, fmt.Errorf("error deleting VCAP secret %s for deployment %s: %w", s.Name, deploymentName, delErr)
+		}
+	}
+	return validVCAPExists, nil
+}
+
+// patches the deployment's container envFrom entries to point to the new VCAP secret name, causing Kubernetes to roll out new
+// pods with the updated credentials.
+func (c *Controller) updateDeploymentVCAPRef(ctx context.Context, namespace string, deployment *appsv1.Deployment, vcapSecretName string) error {
+	updated := deployment.DeepCopy()
+	newEnvFrom := getEnvFrom(vcapSecretName)
+	for j := range updated.Spec.Template.Spec.Containers {
+		updated.Spec.Template.Spec.Containers[j].EnvFrom = newEnvFrom
+	}
+	for j := range updated.Spec.Template.Spec.InitContainers {
+		updated.Spec.Template.Spec.InitContainers[j].EnvFrom = newEnvFrom
+	}
+	if _, err := c.kubeClient.AppsV1().Deployments(namespace).Update(ctx, updated, metav1.UpdateOptions{}); err != nil {
+		return fmt.Errorf("error updating deployment %s for credential rollout: %w", deployment.Name, err)
+	}
+	return nil
+}

--- a/internal/controller/rollout-manager_test.go
+++ b/internal/controller/rollout-manager_test.go
@@ -1,0 +1,1237 @@
+/*
+SPDX-FileCopyrightText: 2026 SAP SE or an SAP affiliate company and cap-operator contributors
+SPDX-License-Identifier: Apache-2.0
+*/
+
+package controller
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8sfake "k8s.io/client-go/kubernetes/fake"
+	k8stesting "k8s.io/client-go/testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+// buildCA creates a CAPApplication with the given services and the
+// RolloutOnCredentialUpdate flag set to enabled.
+func buildCA(name string, rolloutEnabled bool, services []v1alpha1.ServiceInfo) *v1alpha1.CAPApplication {
+	return &v1alpha1.CAPApplication{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				LabelBTPApplicationIdentifierHash: sha1Sum(globalAccountId, btpApplicationName),
+			},
+		},
+		Spec: v1alpha1.CAPApplicationSpec{
+			GlobalAccountId:           globalAccountId,
+			BTPAppName:                btpApplicationName,
+			RolloutOnCredentialUpdate: rolloutEnabled,
+			BTP: v1alpha1.BTP{
+				Services: services,
+			},
+		},
+	}
+}
+
+// buildReadyCAV creates a CAPApplicationVersion in Ready state with the given workloads.
+func buildReadyCAV(name, caName string, workloads []v1alpha1.WorkloadDetails) *v1alpha1.CAPApplicationVersion {
+	return &v1alpha1.CAPApplicationVersion{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				LabelOwnerIdentifierHash: sha1Sum(metav1.NamespaceDefault, caName),
+			},
+		},
+		Spec: v1alpha1.CAPApplicationVersionSpec{
+			CAPApplicationInstance: caName,
+			Version:                "1.0.0",
+			Workloads:              workloads,
+		},
+		Status: v1alpha1.CAPApplicationVersionStatus{
+			GenericStatus: v1alpha1.GenericStatus{
+				Conditions: []metav1.Condition{
+					{Type: string(v1alpha1.ConditionTypeReady), Status: metav1.ConditionTrue},
+				},
+			},
+			State: v1alpha1.CAPApplicationVersionStateReady,
+		},
+	}
+}
+
+// buildReadyTenant creates a CAPTenant in Ready state pointing to cavName.
+func buildReadyTenant(name, caName, cavName string) *v1alpha1.CAPTenant {
+	return &v1alpha1.CAPTenant{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				LabelBTPApplicationIdentifierHash: sha1Sum(globalAccountId, btpApplicationName),
+				LabelTenantId:                     providerTenantId,
+			},
+		},
+		Spec: v1alpha1.CAPTenantSpec{
+			CAPApplicationInstance: caName,
+			BTPTenantIdentification: v1alpha1.BTPTenantIdentification{
+				SubDomain: providerSubDomain,
+				TenantId:  providerTenantId,
+			},
+		},
+		Status: v1alpha1.CAPTenantStatus{
+			State:                                v1alpha1.CAPTenantStateReady,
+			CurrentCAPApplicationVersionInstance: cavName,
+			GenericStatus: v1alpha1.GenericStatus{
+				Conditions: []metav1.Condition{
+					{Type: string(v1alpha1.ConditionTypeReady), Status: metav1.ConditionTrue},
+				},
+			},
+		},
+	}
+}
+
+// buildDeployment creates a minimal Deployment for a workload in the given CAV.
+func buildDeployment(cavName, workloadName, namespace string) *appsv1.Deployment {
+	deployName := getWorkloadName(cavName, workloadName)
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployName,
+			Namespace: namespace,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "server", Image: "test://image", EnvFrom: []corev1.EnvFromSource{}},
+					},
+					InitContainers: []corev1.Container{},
+				},
+			},
+		},
+	}
+}
+
+// btpServices returns a reusable set of service definitions matching the common credential-secrets.
+func btpServices() []v1alpha1.ServiceInfo {
+	return []v1alpha1.ServiceInfo{
+		{Class: "xsuaa", Name: "cap-uaa", Secret: "cap-cap-01-uaa-bind-cf"},
+		{Class: "saas-registry", Name: "cap-saas-registry", Secret: "cap-cap-01-saas-bind-cf"},
+		{Class: "service-manager", Name: "cap-service-manager", Secret: "cap-cap-01-svc-man-bind-cf"},
+	}
+}
+
+// ---------------------------------------------------------------------------
+// getRolloutDelay
+// ---------------------------------------------------------------------------
+
+func TestGetRolloutDelay_DefaultWhenUnset(t *testing.T) {
+	t.Setenv(EnvRolloutDelay, "")
+	if got := getRolloutDelay(); got != defaultRolloutDelay {
+		t.Errorf("expected default %v, got %v", defaultRolloutDelay, got)
+	}
+}
+
+func TestGetRolloutDelay_DefaultWhenEnvVarNotPresent(t *testing.T) {
+	os.Unsetenv(EnvRolloutDelay)
+	t.Cleanup(func() { os.Unsetenv(EnvRolloutDelay) })
+	if got := getRolloutDelay(); got != defaultRolloutDelay {
+		t.Errorf("expected default %v when env var absent, got %v", defaultRolloutDelay, got)
+	}
+}
+
+func TestGetRolloutDelay_ValidDuration(t *testing.T) {
+	t.Setenv(EnvRolloutDelay, "2m")
+	if got := getRolloutDelay(); got != 2*time.Minute {
+		t.Errorf("expected 2m, got %v", got)
+	}
+}
+
+func TestGetRolloutDelay_InvalidDurationFallsBackToDefault(t *testing.T) {
+	t.Setenv(EnvRolloutDelay, "not-a-duration")
+	if got := getRolloutDelay(); got != defaultRolloutDelay {
+		t.Errorf("expected default %v for invalid value, got %v", defaultRolloutDelay, got)
+	}
+}
+
+func TestGetRolloutDelay_WhitespaceOnlyFallsBackToDefault(t *testing.T) {
+	t.Setenv(EnvRolloutDelay, "   ")
+	if got := getRolloutDelay(); got != defaultRolloutDelay {
+		t.Errorf("expected default %v for whitespace-only value, got %v", defaultRolloutDelay, got)
+	}
+}
+
+func TestGetRolloutDelay_BelowMinimumClamped(t *testing.T) {
+	t.Setenv(EnvRolloutDelay, "5s")
+	if got := getRolloutDelay(); got != minRolloutDelay {
+		t.Errorf("expected minimum %v for below-minimum value, got %v", minRolloutDelay, got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// btpServicesForSecrets
+// ---------------------------------------------------------------------------
+
+func TestBtpServicesForSecrets_AllMatch(t *testing.T) {
+	ca := buildCA("test-cap-01", true, btpServices())
+	secrets := map[string]struct{}{
+		"cap-cap-01-uaa-bind-cf":  {},
+		"cap-cap-01-saas-bind-cf": {},
+	}
+	result := btpServicesForSecrets(ca, secrets)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 matched services, got %d", len(result))
+	}
+	if _, ok := result["cap-uaa"]; !ok {
+		t.Error("expected cap-uaa in result")
+	}
+	if _, ok := result["cap-saas-registry"]; !ok {
+		t.Error("expected cap-saas-registry in result")
+	}
+}
+
+func TestBtpServicesForSecrets_NoMatch(t *testing.T) {
+	ca := buildCA("test-cap-01", true, btpServices())
+	secrets := map[string]struct{}{
+		"some-unrelated-secret": {},
+	}
+	result := btpServicesForSecrets(ca, secrets)
+	if len(result) != 0 {
+		t.Fatalf("expected 0 matched services, got %d", len(result))
+	}
+}
+
+func TestBtpServicesForSecrets_EmptySecretSet(t *testing.T) {
+	ca := buildCA("test-cap-01", true, btpServices())
+	result := btpServicesForSecrets(ca, map[string]struct{}{})
+	if len(result) != 0 {
+		t.Fatalf("expected 0 matched services for empty secret set, got %d", len(result))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// workloadConsumesAffectedService
+// ---------------------------------------------------------------------------
+
+func TestWorkloadConsumesAffectedService_Matches(t *testing.T) {
+	workload := &v1alpha1.WorkloadDetails{
+		Name:                "cap-backend",
+		ConsumedBTPServices: []string{"cap-uaa", "cap-service-manager"},
+	}
+	affected := map[string]struct{}{"cap-uaa": {}}
+	if !workloadConsumesAffectedService(workload, affected) {
+		t.Error("expected workload to consume affected service")
+	}
+}
+
+func TestWorkloadConsumesAffectedService_NoMatch(t *testing.T) {
+	workload := &v1alpha1.WorkloadDetails{
+		Name:                "app-router",
+		ConsumedBTPServices: []string{"cap-uaa"},
+	}
+	affected := map[string]struct{}{"cap-service-manager": {}}
+	if workloadConsumesAffectedService(workload, affected) {
+		t.Error("expected workload NOT to consume affected service")
+	}
+}
+
+func TestWorkloadConsumesAffectedService_EmptyConsumed(t *testing.T) {
+	workload := &v1alpha1.WorkloadDetails{
+		Name:                "app-router",
+		ConsumedBTPServices: []string{},
+	}
+	affected := map[string]struct{}{"cap-uaa": {}}
+	if workloadConsumesAffectedService(workload, affected) {
+		t.Error("expected false when workload consumes no services")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// rolloutManager.Enqueue + drainSecrets + restoreSecrets
+// ---------------------------------------------------------------------------
+
+func TestEnqueueAndDrainSecrets_SingleEnqueue(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	m.Enqueue("default", "my-secret")
+
+	drained := m.drainSecrets("default")
+	if len(drained) != 1 {
+		t.Fatalf("expected 1 secret, got %d", len(drained))
+	}
+	if _, ok := drained["my-secret"]; !ok {
+		t.Error("expected my-secret to be present")
+	}
+
+	// second drain must be empty
+	drained2 := m.drainSecrets("default")
+	if len(drained2) != 0 {
+		t.Error("expected empty set after second drain")
+	}
+}
+
+func TestEnqueueAndDrainSecrets_MultipleSecretsCollapsed(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	m.Enqueue("default", "secret-a")
+	m.Enqueue("default", "secret-b")
+	m.Enqueue("default", "secret-a") // duplicate, should not double-count
+
+	drained := m.drainSecrets("default")
+	if len(drained) != 2 {
+		t.Fatalf("expected 2 unique secrets, got %d", len(drained))
+	}
+}
+
+func TestEnqueueAndDrainSecrets_MultipleNamespaces(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	m.Enqueue("ns-a", "secret-x")
+	m.Enqueue("ns-b", "secret-y")
+
+	drainedA := m.drainSecrets("ns-a")
+	drainedB := m.drainSecrets("ns-b")
+
+	if len(drainedA) != 1 {
+		t.Errorf("expected 1 secret for ns-a, got %d", len(drainedA))
+	}
+	if len(drainedB) != 1 {
+		t.Errorf("expected 1 secret for ns-b, got %d", len(drainedB))
+	}
+}
+
+func TestDrainSecrets_UnknownNamespace(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	drained := m.drainSecrets("no-such-namespace")
+	if drained != nil {
+		t.Errorf("expected nil for unknown namespace, got %v", drained)
+	}
+}
+
+func TestRestoreSecrets_MergesIntoExisting(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	m.Enqueue("default", "secret-a")
+	// drain to simulate a failed processing attempt
+	drained := m.drainSecrets("default")
+
+	// a new secret arrived while processing was in-flight
+	m.Enqueue("default", "secret-b")
+
+	// restore the drained set — should merge, not overwrite
+	m.restoreSecrets("default", drained)
+
+	result := m.drainSecrets("default")
+	if len(result) != 2 {
+		t.Fatalf("expected 2 secrets after restore+merge, got %d", len(result))
+	}
+	if _, ok := result["secret-a"]; !ok {
+		t.Error("expected secret-a to be present after restore")
+	}
+	if _, ok := result["secret-b"]; !ok {
+		t.Error("expected secret-b to be present after merge")
+	}
+}
+
+func TestRestoreSecrets_IntoEmptyNamespace(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	m.restoreSecrets("default", map[string]struct{}{"secret-x": {}})
+
+	result := m.drainSecrets("default")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 secret after restore into empty namespace, got %d", len(result))
+	}
+	if _, ok := result["secret-x"]; !ok {
+		t.Error("expected secret-x to be present")
+	}
+}
+
+func TestRestoreSecrets_DeduplicatesOnMerge(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	m.Enqueue("default", "secret-a")
+	drained := m.drainSecrets("default")
+
+	// same secret already re-enqueued by a concurrent Enqueue call
+	m.Enqueue("default", "secret-a")
+	m.restoreSecrets("default", drained)
+
+	result := m.drainSecrets("default")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 secret (no duplicates) after restore+merge, got %d", len(result))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processNamespace
+// ---------------------------------------------------------------------------
+
+func TestProcessNamespace_EmptyAffectedSecrets(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+	m := newRolloutManager(c)
+
+	err := m.processNamespace(context.TODO(), "default", map[string]struct{}{})
+	if err != nil {
+		t.Fatalf("expected no error for empty affected secrets, got: %v", err)
+	}
+}
+
+func TestProcessNamespace_RolloutDisabledOnCA(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", false /* rollout disabled */, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			Name:                "cap-backend",
+			ConsumedBTPServices: []string{"cap-uaa"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+	})
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	m := newRolloutManager(c)
+
+	// Even though the secret matches, rollout should not happen because RolloutOnCredentialUpdate=false
+	err := m.processNamespace(context.TODO(), metav1.NamespaceDefault, map[string]struct{}{
+		"cap-cap-01-uaa-bind-cf": {},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify that no deployment update was attempted
+	actions := c.kubeClient.(*k8sfake.Clientset).Actions()
+	for _, a := range actions {
+		if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+			t.Error("expected no deployment update when rollout is disabled")
+		}
+	}
+}
+
+func TestProcessNamespace_NoMatchingServicesForSecrets(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			Name:                "cap-backend",
+			ConsumedBTPServices: []string{"cap-uaa"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+	})
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	m := newRolloutManager(c)
+
+	// Secret that doesn't match any service in the CA
+	err := m.processNamespace(context.TODO(), metav1.NamespaceDefault, map[string]struct{}{
+		"unrelated-secret": {},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	actions := c.kubeClient.(*k8sfake.Clientset).Actions()
+	for _, a := range actions {
+		if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+			t.Error("expected no deployment update when secret doesn't match any service")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processAffectedApplication
+// ---------------------------------------------------------------------------
+
+func TestProcessAffectedApplication_NoRelevantCAVs(t *testing.T) {
+	defer deregisterMetrics()
+	// CA exists but has no Ready CAVs
+	ca := buildCA("test-cap-01", true, btpServices())
+
+	c := getTestController(testResources{
+		cas: []*v1alpha1.CAPApplication{ca},
+	})
+	m := newRolloutManager(c)
+
+	err := m.processAffectedApplication(context.TODO(), ca, map[string]struct{}{"cap-uaa": {}})
+	if err != nil {
+		t.Fatalf("expected no error when no relevant CAVs, got: %v", err)
+	}
+}
+
+func TestProcessAffectedApplication_WithLatestReadyCAV(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			Name:                "cap-backend",
+			ConsumedBTPServices: []string{"cap-uaa"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+	})
+	deploy := buildDeployment(cav.Name, "cap-backend", metav1.NamespaceDefault)
+
+	// credential secret needed to generate VCAP
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cap-cap-01-uaa-bind-cf", Namespace: metav1.NamespaceDefault},
+		Data:       map[string][]byte{"credentials": []byte(`{"url":"https://auth.local"}`)},
+	}
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	// add objects to fake clients directly
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(deploy)
+	c.kubeInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(deploy)
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(credSecret)
+	c.kubeInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(credSecret)
+
+	m := newRolloutManager(c)
+
+	err := m.processAffectedApplication(context.TODO(), ca, map[string]struct{}{"cap-uaa": {}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// A new VCAP secret should have been created and the deployment updated
+	createdSecret := false
+	updatedDeploy := false
+	for _, a := range c.kubeClient.(*k8sfake.Clientset).Actions() {
+		if a.GetVerb() == "create" && a.GetResource().Resource == "secrets" {
+			createdSecret = true
+		}
+		if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+			updatedDeploy = true
+		}
+	}
+	if !createdSecret {
+		t.Error("expected a new VCAP secret to be created")
+	}
+	if !updatedDeploy {
+		t.Error("expected the deployment to be updated with the new VCAP secret reference")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// processAffectedVersion
+// ---------------------------------------------------------------------------
+
+func TestProcessAffectedVersion_WorkloadWithNoDeploymentDef(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			// job workload — no DeploymentDefinition
+			Name:                "content-job",
+			ConsumedBTPServices: []string{"cap-uaa"},
+		},
+	})
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	m := newRolloutManager(c)
+	err := m.processAffectedVersion(context.TODO(), ca, cav, map[string]struct{}{"cap-uaa": {}})
+	if err != nil {
+		t.Fatalf("unexpected error for job workload: %v", err)
+	}
+
+	// No deployments should be updated for job workloads
+	for _, a := range c.kubeClient.(*k8sfake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+			t.Error("did not expect deployment update for job workload")
+		}
+	}
+}
+
+func TestProcessAffectedVersion_DeploymentNotYetCreated(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			Name:                "cap-backend",
+			ConsumedBTPServices: []string{"cap-uaa"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+	})
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	m := newRolloutManager(c)
+	// No deployment pre-created → should silently skip (not an error)
+	err := m.processAffectedVersion(context.TODO(), ca, cav, map[string]struct{}{"cap-uaa": {}})
+	if err != nil {
+		t.Fatalf("expected no error when deployment doesn't exist yet, got: %v", err)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// replaceVCAPSecret
+// ---------------------------------------------------------------------------
+
+func TestReplaceVCAPSecret_NoExistingSecret(t *testing.T) {
+	defer deregisterMetrics()
+	c := getTestController(testResources{})
+
+	ownerRef := metav1.OwnerReference{Name: "test-cap-01-cav-v1"}
+	// When no secret exists, should complete without error and return unchanged=false
+	unchanged, err := c.checkVCAPSecret(context.TODO(), metav1.NamespaceDefault, "test-cap-01-cav-v1-cap-backend", ownerRef, []byte(`{"xsuaa":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error when no VCAP secret exists: %v", err)
+	}
+	if unchanged {
+		t.Error("expected unchanged=false when no VCAP secret exists")
+	}
+}
+
+func TestReplaceVCAPSecret_DeletesExistingSecret(t *testing.T) {
+	defer deregisterMetrics()
+
+	cavName := "test-cap-01-cav-v1"
+	deployName := "test-cap-01-cav-v1-cap-backend"
+	ownerRef := metav1.OwnerReference{Name: cavName}
+
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployName + "-vcap-gen",
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				LabelSecretOwnerHash: sha1Sum(metav1.NamespaceDefault, cavName, deployName),
+			},
+		},
+		Data: map[string][]byte{
+			EnvVCAPServices: []byte(`{"old":[]}`),
+		},
+	}
+
+	c := getTestController(testResources{})
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(existingSecret)
+	c.kubeInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(existingSecret)
+
+	unchanged, err := c.checkVCAPSecret(context.TODO(), metav1.NamespaceDefault, deployName, ownerRef, []byte(`{"new":[]}`))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if unchanged {
+		t.Error("expected unchanged=false when content differs")
+	}
+
+	deletedSecret := false
+	for _, a := range c.kubeClient.(*k8sfake.Clientset).Actions() {
+		if a.GetVerb() == "delete" && a.GetResource().Resource == "secrets" {
+			deletedSecret = true
+		}
+	}
+	if !deletedSecret {
+		t.Error("expected existing VCAP secret to be deleted")
+	}
+}
+
+func TestReplaceVCAPSecret_UnchangedContentSkipsDelete(t *testing.T) {
+	defer deregisterMetrics()
+
+	cavName := "test-cap-01-cav-v1"
+	deployName := "test-cap-01-cav-v1-cap-backend"
+	ownerRef := metav1.OwnerReference{Name: cavName}
+	vcapContent := []byte(`{"xsuaa":[{"credentials":{"url":"https://auth.local"}}]}`)
+
+	existingSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deployName + "-vcap-gen",
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				LabelSecretOwnerHash: sha1Sum(metav1.NamespaceDefault, cavName, deployName),
+			},
+		},
+		Data: map[string][]byte{
+			EnvVCAPServices: vcapContent,
+		},
+	}
+
+	c := getTestController(testResources{})
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(existingSecret)
+	c.kubeInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(existingSecret)
+
+	unchanged, err := c.checkVCAPSecret(context.TODO(), metav1.NamespaceDefault, deployName, ownerRef, vcapContent)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !unchanged {
+		t.Error("expected unchanged=true when VCAP content is identical")
+	}
+
+	for _, a := range c.kubeClient.(*k8sfake.Clientset).Actions() {
+		if a.GetVerb() == "delete" && a.GetResource().Resource == "secrets" {
+			t.Error("expected no secret deletion when content is unchanged")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// updateDeploymentVCAPRef
+// ---------------------------------------------------------------------------
+
+func TestUpdateDeploymentVCAPRef_UpdatesContainersAndInitContainers(t *testing.T) {
+	defer deregisterMetrics()
+
+	deploy := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-cap-01-cav-v1-cap-backend",
+			Namespace: metav1.NamespaceDefault,
+		},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{Name: "server", EnvFrom: []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "old-vcap"}}}}},
+					},
+					InitContainers: []corev1.Container{
+						{Name: "init", EnvFrom: []corev1.EnvFromSource{{SecretRef: &corev1.SecretEnvSource{LocalObjectReference: corev1.LocalObjectReference{Name: "old-vcap"}}}}},
+					},
+				},
+			},
+		},
+	}
+
+	c := getTestController(testResources{})
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(deploy)
+
+	err := c.updateDeploymentVCAPRef(context.TODO(), metav1.NamespaceDefault, deploy, "new-vcap-secret")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	updated, err := c.kubeClient.AppsV1().Deployments(metav1.NamespaceDefault).Get(context.TODO(), deploy.Name, metav1.GetOptions{})
+	if err != nil {
+		t.Fatalf("could not retrieve updated deployment: %v", err)
+	}
+
+	for _, ctr := range updated.Spec.Template.Spec.Containers {
+		if len(ctr.EnvFrom) == 0 || ctr.EnvFrom[0].SecretRef.Name != "new-vcap-secret" {
+			t.Errorf("container %s: expected EnvFrom to reference new-vcap-secret", ctr.Name)
+		}
+	}
+	for _, ctr := range updated.Spec.Template.Spec.InitContainers {
+		if len(ctr.EnvFrom) == 0 || ctr.EnvFrom[0].SecretRef.Name != "new-vcap-secret" {
+			t.Errorf("init container %s: expected EnvFrom to reference new-vcap-secret", ctr.Name)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// collectRelevantCAVs
+// ---------------------------------------------------------------------------
+
+func TestCollectRelevantCAVs_LatestReadyOnly(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{})
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+
+	relevant, err := c.collectRelevantCAVs(ca)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(relevant) != 1 {
+		t.Fatalf("expected 1 relevant CAV, got %d", len(relevant))
+	}
+	if _, ok := relevant[cav.Name]; !ok {
+		t.Errorf("expected %s to be in relevant CAVs", cav.Name)
+	}
+}
+
+func TestCollectRelevantCAVs_DeduplicatesLatestAndTenantCAV(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{})
+
+	// Tenant also references the same CAV
+	tenant := buildReadyTenant("test-cap-01-provider", ca.Name, cav.Name)
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+		cats: []*v1alpha1.CAPTenant{tenant},
+	})
+
+	relevant, err := c.collectRelevantCAVs(ca)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// Even though the CAV appears as both latest and tenant CAV, it should be deduplicated
+	if len(relevant) != 1 {
+		t.Fatalf("expected 1 deduplicated CAV, got %d", len(relevant))
+	}
+}
+
+func TestCollectRelevantCAVs_TenantReferencesAdditionalCAV(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+
+	// Latest ready CAV
+	latestCAV := buildReadyCAV("test-cap-01-cav-v2", ca.Name, []v1alpha1.WorkloadDetails{})
+	latestCAV.Spec.Version = "2.0.0"
+
+	// Older CAV still in use by a tenant
+	oldCAV := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{})
+	oldCAV.Spec.Version = "1.0.0"
+
+	tenant := buildReadyTenant("test-cap-01-provider", ca.Name, oldCAV.Name)
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{latestCAV, oldCAV},
+		cats: []*v1alpha1.CAPTenant{tenant},
+	})
+
+	relevant, err := c.collectRelevantCAVs(ca)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(relevant) != 2 {
+		t.Fatalf("expected 2 relevant CAVs (latest + tenant), got %d", len(relevant))
+	}
+	if _, ok := relevant[latestCAV.Name]; !ok {
+		t.Errorf("expected latestCAV %s to be relevant", latestCAV.Name)
+	}
+	if _, ok := relevant[oldCAV.Name]; !ok {
+		t.Errorf("expected oldCAV %s to be relevant (used by tenant)", oldCAV.Name)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// enqueuePendingRollouts
+// ---------------------------------------------------------------------------
+
+func TestEnqueuePendingRollouts_NoRelevantCAs(t *testing.T) {
+	defer deregisterMetrics()
+	// CA with rollout disabled — nothing should be enqueued
+	ca := buildCA("test-cap-01", false, btpServices())
+	c := getTestController(testResources{cas: []*v1alpha1.CAPApplication{ca}})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	if err := m.enqueuePendingRollouts(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if m.queue.Len() != 0 {
+		t.Errorf("expected empty queue for CA with rollout disabled, got %d items", m.queue.Len())
+	}
+}
+
+func TestEnqueuePendingRollouts_EnqueuesNamespaceForRelevantCA(t *testing.T) {
+	defer deregisterMetrics()
+	ca := buildCA("test-cap-01", true, btpServices())
+	c := getTestController(testResources{cas: []*v1alpha1.CAPApplication{ca}})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	if err := m.enqueuePendingRollouts(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// All 3 BTP service secrets should have been recorded for the namespace
+	drained := m.drainSecrets(metav1.NamespaceDefault)
+	if len(drained) != len(btpServices()) {
+		t.Errorf("expected %d secrets enqueued, got %d", len(btpServices()), len(drained))
+	}
+	for _, svc := range btpServices() {
+		if _, ok := drained[svc.Secret]; !ok {
+			t.Errorf("expected secret %s to be enqueued", svc.Secret)
+		}
+	}
+}
+
+func TestEnqueuePendingRollouts_MultipleCAsSameNamespaceDeduplicatesSecrets(t *testing.T) {
+	defer deregisterMetrics()
+	// Two CAs in the same namespace sharing one secret — should only enqueue it once
+	sharedSecret := "shared-secret"
+	ca1 := buildCA("test-cap-01", true, []v1alpha1.ServiceInfo{
+		{Class: "xsuaa", Name: "svc-a", Secret: sharedSecret},
+	})
+	ca2 := buildCA("test-cap-02", true, []v1alpha1.ServiceInfo{
+		{Class: "xsuaa", Name: "svc-b", Secret: sharedSecret},
+		{Class: "saas-registry", Name: "svc-c", Secret: "unique-secret"},
+	})
+	c := getTestController(testResources{cas: []*v1alpha1.CAPApplication{ca1, ca2}})
+	m := newRolloutManager(c)
+	defer m.queue.ShutDown()
+
+	if err := m.enqueuePendingRollouts(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	drained := m.drainSecrets(metav1.NamespaceDefault)
+	if len(drained) != 2 {
+		t.Errorf("expected 2 unique secrets (shared deduped), got %d", len(drained))
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Full rollout path through processNamespace
+// ---------------------------------------------------------------------------
+
+func TestProcessNamespace_FullRollout(t *testing.T) {
+	defer deregisterMetrics()
+
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			Name:                "cap-backend",
+			ConsumedBTPServices: []string{"cap-uaa"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+		{
+			// App-router does NOT consume cap-uaa, should not be rolled out
+			Name:                "app-router",
+			ConsumedBTPServices: []string{"cap-saas-registry"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+	})
+
+	backendDeploy := buildDeployment(cav.Name, "cap-backend", metav1.NamespaceDefault)
+	routerDeploy := buildDeployment(cav.Name, "app-router", metav1.NamespaceDefault)
+
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cap-cap-01-uaa-bind-cf", Namespace: metav1.NamespaceDefault},
+		Data:       map[string][]byte{"credentials": []byte(`{"url":"https://auth.local"}`)},
+	}
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	for _, obj := range []interface{ GetName() string }{backendDeploy, routerDeploy} {
+		switch o := obj.(type) {
+		case *appsv1.Deployment:
+			c.kubeClient.(*k8sfake.Clientset).Tracker().Add(o)
+			c.kubeInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(o)
+		}
+	}
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(credSecret)
+	c.kubeInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(credSecret)
+
+	m := newRolloutManager(c)
+
+	err := m.processNamespace(context.TODO(), metav1.NamespaceDefault, map[string]struct{}{
+		"cap-cap-01-uaa-bind-cf": {},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error during full rollout: %v", err)
+	}
+
+	updatedDeployments := map[string]bool{}
+	for _, a := range c.kubeClient.(*k8sfake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+			ua := a.(k8stesting.UpdateAction)
+			dep := ua.GetObject().(*appsv1.Deployment)
+			updatedDeployments[dep.Name] = true
+		}
+	}
+
+	if !updatedDeployments[backendDeploy.Name] {
+		t.Errorf("expected cap-backend deployment to be rolled out")
+	}
+	if updatedDeployments[routerDeploy.Name] {
+		t.Errorf("expected app-router NOT to be rolled out (doesn't consume affected service)")
+	}
+}
+
+func TestProcessNamespace_SkipsRolloutWhenVCAPUnchanged(t *testing.T) {
+	defer deregisterMetrics()
+
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			Name:                "cap-backend",
+			ConsumedBTPServices: []string{"cap-uaa"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+	})
+
+	backendDeploy := buildDeployment(cav.Name, "cap-backend", metav1.NamespaceDefault)
+
+	credSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{Name: "cap-cap-01-uaa-bind-cf", Namespace: metav1.NamespaceDefault},
+		Data:       map[string][]byte{"credentials": []byte(`{"url":"https://auth.local"}`)},
+	}
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(backendDeploy)
+	c.kubeInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(backendDeploy)
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(credSecret)
+	c.kubeInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(credSecret)
+
+	// Pre-compute the VCAP content that rolloutWorkloadDeployment would generate,
+	// then seed a secret with that exact content so checkVCAPSecret returns unchanged=true.
+	deploymentName := getWorkloadName(cav.Name, "cap-backend")
+	ownerRef := *metav1.NewControllerRef(cav, v1alpha1.SchemeGroupVersion.WithKind(v1alpha1.CAPApplicationVersionKind))
+	consumedServiceInfos := getConsumedServiceInfos(getConsumedServiceMap([]string{"cap-uaa"}), ca.Spec.BTP.Services)
+	vcapEnv, err := generateVCAPEnv(metav1.NamespaceDefault, consumedServiceInfos, c.kubeInformerFactory)
+	if err != nil {
+		t.Fatalf("failed to pre-generate VCAP env: %v", err)
+	}
+	existingVCAPSecret := &corev1.Secret{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName + "-vcap-existing",
+			Namespace: metav1.NamespaceDefault,
+			Labels: map[string]string{
+				LabelSecretOwnerHash: sha1Sum(metav1.NamespaceDefault, ownerRef.Name, deploymentName),
+			},
+		},
+		Data: map[string][]byte{
+			EnvVCAPServices: vcapEnv,
+		},
+	}
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(existingVCAPSecret)
+	c.kubeInformerFactory.Core().V1().Secrets().Informer().GetIndexer().Add(existingVCAPSecret)
+
+	m := newRolloutManager(c)
+
+	err = m.processNamespace(context.TODO(), metav1.NamespaceDefault, map[string]struct{}{
+		"cap-cap-01-uaa-bind-cf": {},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	for _, a := range c.kubeClient.(*k8sfake.Clientset).Actions() {
+		if a.GetVerb() == "update" && a.GetResource().Resource == "deployments" {
+			t.Error("expected no deployment update when VCAP_SERVICES content is unchanged")
+		}
+		if a.GetVerb() == "create" && a.GetResource().Resource == "secrets" {
+			t.Error("expected no new VCAP secret to be created when content is unchanged")
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Queue-based worker loop
+// ---------------------------------------------------------------------------
+
+// waitFor polls pred every 10 ms until it returns true or timeout elapses.
+func waitFor(t *testing.T, timeout time.Duration, pred func() bool) bool {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if pred() {
+			return true
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	return false
+}
+
+// newFastRolloutManager returns a rolloutManager with rolloutDelay=0 so
+// AddAfter fires immediately in tests.
+func newFastRolloutManager(c *Controller) *rolloutManager {
+	m := newRolloutManager(c)
+	m.rolloutDelay = 0
+	return m
+}
+
+// TestStartWorker_SuccessPath verifies that after a successful processNamespace
+// the item is Forgotten (requeue count resets to 0) and Done is called so the
+// queue length returns to 0.
+func TestStartWorker_SuccessPath(t *testing.T) {
+	defer deregisterMetrics()
+
+	ca := buildCA("test-cap-01", true, btpServices())
+	c := getTestController(testResources{cas: []*v1alpha1.CAPApplication{ca}})
+	m := newFastRolloutManager(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Start(ctx)
+
+	// Enqueue a namespace with a secret that matches no service → processNamespace
+	// succeeds (returns nil) without touching Kubernetes.
+	m.Enqueue(metav1.NamespaceDefault, "unrelated-secret")
+
+	// The worker should drain the item and forget it; queue must reach length 0.
+	if !waitFor(t, 2*time.Second, func() bool { return m.queue.Len() == 0 }) {
+		t.Fatal("queue did not drain after successful processing")
+	}
+
+	// Requeue counter must be 0 — Forget was called on the success path.
+	if got := m.queue.NumRequeues(metav1.NamespaceDefault); got != 0 {
+		t.Errorf("expected 0 requeues after success, got %d", got)
+	}
+}
+
+// TestStartWorker_ErrorPathRestoresSecretsAndRequeues verifies the error branch
+// of the queue worker (lines 133-135): when processNamespace returns an error
+// (here: the credential secret referenced by a workload's ConsumedBTPServices is
+// absent, causing generateVCAPEnv to fail inside rolloutWorkloadDeployment),
+// the worker must restore the drained secrets and rate-limit the item for retry.
+func TestStartWorker_ErrorPathRestoresSecretsAndRequeues(t *testing.T) {
+	defer deregisterMetrics()
+
+	ca := buildCA("test-cap-01", true, btpServices())
+	cav := buildReadyCAV("test-cap-01-cav-v1", ca.Name, []v1alpha1.WorkloadDetails{
+		{
+			Name:                "cap-backend",
+			ConsumedBTPServices: []string{"cap-uaa"},
+			DeploymentDefinition: &v1alpha1.DeploymentDetails{
+				CommonDetails: v1alpha1.CommonDetails{Image: "test://image"},
+			},
+		},
+	})
+	// Deployment exists so rolloutWorkloadDeployment proceeds past the IsNotFound skip ...
+	deploy := buildDeployment(cav.Name, "cap-backend", metav1.NamespaceDefault)
+
+	c := getTestController(testResources{
+		cas:  []*v1alpha1.CAPApplication{ca},
+		cavs: []*v1alpha1.CAPApplicationVersion{cav},
+	})
+	c.kubeClient.(*k8sfake.Clientset).Tracker().Add(deploy)
+	c.kubeInformerFactory.Apps().V1().Deployments().Informer().GetIndexer().Add(deploy)
+	// ... but the credential secret is intentionally absent so generateVCAPEnv errors.
+
+	m := newFastRolloutManager(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Start(ctx)
+
+	m.Enqueue(metav1.NamespaceDefault, "cap-cap-01-uaa-bind-cf")
+
+	// Wait until the worker has hit the error path and rate-limited the item.
+	if !waitFor(t, 2*time.Second, func() bool {
+		return m.queue.NumRequeues(metav1.NamespaceDefault) >= 1
+	}) {
+		t.Fatal("item was not rate-limited after processing error")
+	}
+
+	// Secret must have been restored into pendingSecrets for the retry.
+	m.mu.Lock()
+	_, restored := m.pendingSecrets[metav1.NamespaceDefault]["cap-cap-01-uaa-bind-cf"]
+	m.mu.Unlock()
+	if !restored {
+		t.Error("expected cap-cap-01-uaa-bind-cf to be restored into pendingSecrets after error")
+	}
+}
+
+// TestStartWorker_ShutdownDrainsWorkers verifies that cancelling the context
+// causes Start to return (workers notice shutdown and exit).
+func TestStartWorker_ShutdownDrainsWorkers(t *testing.T) {
+	defer deregisterMetrics()
+
+	c := getTestController(testResources{})
+	m := newFastRolloutManager(c)
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan struct{})
+	go func() {
+		m.Start(ctx)
+		close(done)
+	}()
+
+	cancel()
+
+	select {
+	case <-done:
+		// Start returned as expected
+	case <-time.After(3 * time.Second):
+		t.Fatal("Start did not return after context cancellation")
+	}
+}
+
+// TestStartWorker_DrainSecretsCalledBeforeProcessing verifies that the worker
+// atomically drains pendingSecrets before calling processNamespace, so secrets
+// enqueued after the drain but before completion are not lost.
+func TestStartWorker_DrainSecretsCalledBeforeProcessing(t *testing.T) {
+	defer deregisterMetrics()
+
+	ca := buildCA("test-cap-01", true, btpServices())
+	c := getTestController(testResources{cas: []*v1alpha1.CAPApplication{ca}})
+	m := newFastRolloutManager(c)
+
+	// Pre-populate two secrets for the same namespace.
+	m.Enqueue(metav1.NamespaceDefault, "secret-a")
+	m.Enqueue(metav1.NamespaceDefault, "secret-b")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go m.Start(ctx)
+
+	// Both secrets should be consumed in the single processing pass (batching).
+	// pendingSecrets for the namespace should be empty once the queue is drained.
+	if !waitFor(t, 2*time.Second, func() bool {
+		return m.queue.Len() == 0
+	}) {
+		t.Fatal("queue did not drain after processing both secrets")
+	}
+
+	m.mu.Lock()
+	remaining := len(m.pendingSecrets[metav1.NamespaceDefault])
+	m.mu.Unlock()
+
+	if remaining != 0 {
+		t.Errorf("expected pendingSecrets to be empty after drain, got %d entries", remaining)
+	}
+}

--- a/pkg/apis/sme.sap.com/v1alpha1/types.go
+++ b/pkg/apis/sme.sap.com/v1alpha1/types.go
@@ -105,6 +105,8 @@ type CAPApplicationSpec struct {
 	Provider *BTPTenantIdentification `json:"provider,omitempty"`
 	// SAP BTP Services consumed by the application
 	BTP BTP `json:"btp"`
+	// Rollout on Credentials Update may be used to rollout deployments when dependant service credentials are updated
+	RolloutOnCredentialUpdate bool `json:"rolloutOnCredentialUpdate,omitempty"`
 }
 
 // Domain references

--- a/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/capapplicationspec.go
+++ b/pkg/client/applyconfiguration/sme.sap.com/v1alpha1/capapplicationspec.go
@@ -28,6 +28,8 @@ type CAPApplicationSpecApplyConfiguration struct {
 	Provider *BTPTenantIdentificationApplyConfiguration `json:"provider,omitempty"`
 	// SAP BTP Services consumed by the application
 	BTP *BTPApplyConfiguration `json:"btp,omitempty"`
+	// Rollout on Credentials Update may be used to rollout deployments when dependant service credentials are updated
+	RolloutOnCredentialUpdate *bool `json:"rolloutOnCredentialUpdate,omitempty"`
 }
 
 // CAPApplicationSpecApplyConfiguration constructs a declarative configuration of the CAPApplicationSpec type for use with
@@ -94,5 +96,13 @@ func (b *CAPApplicationSpecApplyConfiguration) WithProvider(value *BTPTenantIden
 // If called multiple times, the BTP field is set to the value of the last call.
 func (b *CAPApplicationSpecApplyConfiguration) WithBTP(value *BTPApplyConfiguration) *CAPApplicationSpecApplyConfiguration {
 	b.BTP = value
+	return b
+}
+
+// WithRolloutOnCredentialUpdate sets the RolloutOnCredentialUpdate field in the declarative configuration to the given value
+// and returns the receiver, so that objects can be built by chaining "With" function invocations.
+// If called multiple times, the RolloutOnCredentialUpdate field is set to the value of the last call.
+func (b *CAPApplicationSpecApplyConfiguration) WithRolloutOnCredentialUpdate(value bool) *CAPApplicationSpecApplyConfiguration {
+	b.RolloutOnCredentialUpdate = &value
 	return b
 }

--- a/website/content/en/docs/usage/deploying-application.md
+++ b/website/content/en/docs/usage/deploying-application.md
@@ -172,3 +172,5 @@ Once these resources are available, the `CAPApplicationVersion` status changes t
 > The `CAPApplicationVersion` resource is immutable — its spec must not be modified after deployment. This is enforced by webhooks, which we recommend keeping active (the default).
 
 > NOTE: Follow the recommended [security measures](../security) to safeguard exposed workloads.
+
+> NOTE: If SAP BTP service credentials are rotated after deployment, CAP Operator can automatically restart affected workloads. See [Rollout on Credential Update](../rollout-on-credential-update) to learn how to enable this.

--- a/website/content/en/docs/usage/resources/capapplication.md
+++ b/website/content/en/docs/usage/resources/capapplication.md
@@ -62,3 +62,5 @@ The `domainRefs` section references one or more `Domain` or `ClusterDomain` reso
 > NOTE: While the same secondary domain can technically be shared across applications using `ClusterDomain`, tenant subdomains must be unique across all applications sharing that domain.
 
 > NOTE: The `provider` section must always be omitted for [services-only applications](../../service-exposure/#deploying-services-only-applications).
+
+The optional `rolloutOnCredentialUpdate` field enables automatic rolling restarts of affected Deployments when the referenced BTP service credential Secrets are updated. See [Rollout on Credential Update](../../rollout-on-credential-update) for details.

--- a/website/content/en/docs/usage/rollout-on-credential-update.md
+++ b/website/content/en/docs/usage/rollout-on-credential-update.md
@@ -1,0 +1,99 @@
+---
+title: "Rollout on Credential Update"
+linkTitle: "Rollout on Credential Update"
+weight: 45
+type: "docs"
+description: >
+  Automatically roll out application workloads when BTP service credentials are rotated
+---
+
+When SAP BTP service credentials are rotated — for example, by a credential rotation tool or by re-binding a service instance — the Kubernetes Secrets holding those credentials are updated. By default, running application workloads are **not** restarted and continue to use the old credentials until the next deployment or a manual rollout.
+
+Enabling `rolloutOnCredentialUpdate` on a `CAPApplication` resource instructs CAP Operator to watch the referenced BTP service credential Secrets and automatically trigger a rolling restart of affected Deployments whenever their credentials change.
+
+## Benefits
+
+| Benefit | Description |
+|---|---|
+| No stale credentials in running pods | Pods pick up fresh credentials without a manual rollout or a new `CAPApplicationVersion`. |
+| Selective restarts | Only Deployments that actually consume the updated service are restarted; unaffected workloads are left untouched. |
+| Resilient to operator restarts | On startup, CAP Operator re-checks all relevant Secrets so that credential changes that occurred while the operator was down are not missed. |
+| Batched processing | Multiple Secret updates arriving within the batching window are accumulated and processed in a single pass, avoiding redundant rollouts. |
+
+## Enabling the Feature
+
+Set `rolloutOnCredentialUpdate: true` in the `CAPApplication` spec:
+
+```yaml
+apiVersion: sme.sap.com/v1alpha1
+kind: CAPApplication
+metadata:
+  name: cap-app-01
+  namespace: cap-app-01
+spec:
+  rolloutOnCredentialUpdate: true # opt-in to automatic rollout on credential rotation
+  btpAppName: cap-app-01
+  btp:
+    services:
+      - class: xsuaa
+        name: app-uaa
+        secret: cap-app-01-uaa-bind-cf
+      - class: saas-registry
+        name: app-saas-registry
+        secret: cap-app-01-saas-bind-cf
+      - class: service-manager
+        name: app-service-manager
+        secret: cap-app-01-svc-man-bind-cf
+  domainRefs:
+    - kind: ClusterDomain
+      name: common-external-domain
+  providerSubaccountId: provider-subaccount-id
+```
+
+The field is optional and defaults to `false`. See the [API Reference](../../reference/#sme.sap.com/v1alpha1.CAPApplication) for the full spec.
+
+## How It Works
+
+Once enabled, the operator follows this flow whenever a watched Secret changes:
+
+1. **Secret watch** — CAP Operator watches all Kubernetes Secrets in the namespace of any `CAPApplication` that has `rolloutOnCredentialUpdate: true`. When a Secret is updated, the namespace is scheduled for processing after a configurable batching window (see [Operator Configuration](#operator-configuration)).
+
+2. **Batching** — any additional Secret changes arriving in the same namespace within the batching window are accumulated. When the window expires, all collected changes are processed together in a single pass, preventing redundant rollouts when multiple services are rotated at once.
+
+3. **Affected workload detection** — for each `CAPApplicationVersion` currently in use (the latest ready version, plus any version still serving active tenants), the operator checks which Deployments declare the rotated service in their `consumedBTPServices` list.
+
+4. **VCAP secret comparison** — the operator rebuilds the `VCAP_SERVICES` data for each affected Deployment using the new credential data. If the payload is identical to the existing one, the Deployment is left untouched and no restart is triggered.
+
+5. **Rolling restart** — when the data has changed, a new `VCAP_SERVICES` secret is created and the Deployment's `envFrom` reference is updated to point to it. Kubernetes detects the change and performs a rolling restart of the pods, ensuring zero downtime.
+
+> **Note:** Only Deployments are restarted. Job workloads (content deployers, tenant operation jobs) are not affected by this feature.
+
+> **Note:** The rollout covers all ready `CAPApplicationVersion` resources currently serving tenants, not only the latest version. This ensures credentials are refreshed consistently across all active versions during an upgrade transition.
+
+## Operator Configuration
+
+The batching window duration is configurable via an environment variable on the CAP Operator deployment.
+
+| Environment Variable | Description | Default | Minimum |
+|---|---|---|---|
+| `ROLLOUT_DELAY` | How long the operator waits after a credential Secret is updated before processing the rollout. Secret changes arriving within this window for the same namespace are batched into a single pass. Accepts any Go duration string (e.g. `30m`, `2h`). | `1h` | `30s` |
+
+If the configured value cannot be parsed, the operator logs an error and falls back to the default (`1h`). If the parsed value is below the minimum (`30s`), the operator logs an error and clamps it to `30s`.
+
+
+## Recommendations
+
+### Keep Old Credentials Valid Long After Rotation
+
+When rotating credentials, **do not invalidate the old Secret immediately**. CAP Operator needs time to:
+
+1. detect the Secret change,
+2. wait out the batching window (`ROLLOUT_DELAY`),
+3. rebuild and compare the `VCAP_SERVICES` payload, and
+4. wait for Kubernetes to complete the rolling restart of every affected Deployment.
+
+Only once all pods are running with the new credentials is it safe to revoke the old ones.
+
+As a rule of thumb, keep the old credentials valid for **at least 24 hours** after issuing the new ones. This provides a generous buffer that covers the batching delay, the rollout duration, and any transient failures or retries in the operator's reconciliation loop.
+
+Revoking credentials too soon risks pods being restarted mid-rollout with no valid credentials available, which causes application downtime.

--- a/website/includes/api-reference.html
+++ b/website/includes/api-reference.html
@@ -166,6 +166,17 @@ BTP
 <p>SAP BTP Services consumed by the application</p>
 </td>
 </tr>
+<tr>
+<td>
+<code>rolloutOnCredentialUpdate</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Rollout on Credentials Update may be used to rollout deployments when dependant service credentials are updated</p>
+</td>
+</tr>
 </table>
 </td>
 </tr>
@@ -1231,6 +1242,17 @@ BTP
 </td>
 <td>
 <p>SAP BTP Services consumed by the application</p>
+</td>
+</tr>
+<tr>
+<td>
+<code>rolloutOnCredentialUpdate</code><br/>
+<em>
+bool
+</em>
+</td>
+<td>
+<p>Rollout on Credentials Update may be used to rollout deployments when dependant service credentials are updated</p>
 </td>
 </tr>
 </tbody>
@@ -3995,5 +4017,5 @@ If not specified, CAP Operator will not attempt to create a ServiceMonitor for t
 <hr/>
 <p><em>
 Generated with <code>gen-crd-api-reference-docs</code>
-on git commit <code>13ce036</code>.
+on git commit <code>71b5c8e</code>.
 </em></p>


### PR DESCRIPTION
Add opt-in rollout of application workloads when service credentials
are updated.

- New `rolloutOnCredentialUpdate` field on CAPApplicationSpec enables
  the feature per application
- Secret informer watches for credential changes and enqueues affected
  namespaces via a new rolloutManager
- Rollout delay batches multiple changes within a configurable window
  (ROLLOUT_DELAY env var, default 1h, minimum 30s) into a single pass