### PR TITLE
[Misc] scan: Build failures ignored

### DIFF
--- a/.github/workflows/scan-container.yaml
+++ b/.github/workflows/scan-container.yaml
@@ -41,6 +41,7 @@ jobs:
       - name: Run grype scanner
         uses: anchore/scan-action@v7
         with:
+          fail-build: false
           image: ghcr.io/sap/cap-operator/${{ matrix.workload }}:${{ inputs.version || 'latest' }}
           output-file: 'vuln-grype-${{ matrix.workload }}.sarif'
 


### PR DESCRIPTION
Do not fail builds when vulnerabilities are detected, instead upload the results to security tab.