### PR TITLE
[Misc] Operator: go unit testing env used

### DIFF
--- a/internal/controller/reconcile-captenant_test.go
+++ b/internal/controller/reconcile-captenant_test.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"os"
 	"testing"
 
 	"github.com/sap/cap-operator/pkg/apis/sme.sap.com/v1alpha1"
@@ -286,8 +285,7 @@ func TestCAPTenantUpgradeOperationCompleted(t *testing.T) {
 }
 
 func TestCAPTenantUpgradeOperationCompletedPreviousVersionsLimited(t *testing.T) {
-	os.Setenv(v1alpha1.EnvMaxTenantVersionHistory, "3")
-	defer os.Unsetenv(v1alpha1.EnvMaxTenantVersionHistory)
+	t.Setenv(v1alpha1.EnvMaxTenantVersionHistory, "3")
 	reconcileTestItem(
 		context.TODO(), t,
 		QueueItem{Key: ResourceCAPTenant, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-cap-01-provider"}},

--- a/internal/controller/reconcile-captenantoperation_test.go
+++ b/internal/controller/reconcile-captenantoperation_test.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"os"
 	"testing"
 )
 
@@ -54,8 +53,7 @@ func TestTenantOperationInitializeStep(t *testing.T) {
 func TestTenantOperationWithNoSteps(t *testing.T) {
 	// Env set for this test to enable coverage for detailed metrics --> this has no impact on tenant operation code/test as such.
 	detailedMetrics := "DETAILED_OPERATIONAL_METRICS"
-	defer os.Unsetenv(detailedMetrics)
-	os.Setenv(detailedMetrics, "true")
+	t.Setenv(detailedMetrics, "true")
 	err := reconcileTestItem(
 		context.TODO(), t,
 		QueueItem{Key: ResourceCAPTenantOperation, ResourceKey: NamespacedResourceKey{Namespace: "default", Name: "test-cap-01-provider-abcd"}},

--- a/internal/controller/reconcile-domain_test.go
+++ b/internal/controller/reconcile-domain_test.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"os"
 	"testing"
 )
 
@@ -132,7 +131,7 @@ func TestDomain_ProcessingWithIngressWithAdditionalCACertificateCreateFailed(t *
 }
 
 func TestDomain_ProcessingWithIngressCertManager(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -148,11 +147,11 @@ func TestDomain_ProcessingWithIngressCertManager(t *testing.T) {
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_ProcessingWithIngressCertManagerCustomIssuerRef(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -168,11 +167,11 @@ func TestDomain_ProcessingWithIngressCertManagerCustomIssuerRef(t *testing.T) {
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_ProcessingWithIngressCertManagerCommonName(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -188,11 +187,11 @@ func TestDomain_ProcessingWithIngressCertManagerCommonName(t *testing.T) {
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_ProcessingWithIngressCertManagerCustomIssuerRefAndCommonName(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -208,11 +207,11 @@ func TestDomain_ProcessingWithIngressCertManagerCustomIssuerRefAndCommonName(t *
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_ProcessingWithIngressCertManagerWithAdditionalCACertificate(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -228,7 +227,7 @@ func TestDomain_ProcessingWithIngressCertManagerWithAdditionalCACertificate(t *t
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_ProcessingWithIngressCertGateway(t *testing.T) {
@@ -303,7 +302,7 @@ func TestDomain_Ready(t *testing.T) {
 }
 
 func TestDomain_ReadyWithCertManager(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -321,7 +320,7 @@ func TestDomain_ReadyWithCertManager(t *testing.T) {
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_DnsError(t *testing.T) {
@@ -371,7 +370,7 @@ func TestDomain_CertificateError(t *testing.T) {
 }
 
 func TestDomain_CertManagerError(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	err := reconcileTestItem(
 		context.TODO(), t,
@@ -394,7 +393,7 @@ func TestDomain_CertManagerError(t *testing.T) {
 		t.Error("Wrong error message")
 	}
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_UpdateDomain(t *testing.T) {
@@ -547,7 +546,7 @@ func TestDomain_RemoveAdditionalCACertificateDeleteError(t *testing.T) {
 }
 
 func TestDomain_UpdateCertManagerConfig(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -565,11 +564,11 @@ func TestDomain_UpdateCertManagerConfig(t *testing.T) {
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_UpdateDomainWithCertManager(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -588,7 +587,7 @@ func TestDomain_UpdateDomainWithCertManager(t *testing.T) {
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_DeletionTimestampSet(t *testing.T) {
@@ -663,7 +662,7 @@ func TestDomain_DeletingWithCertSecretDeleteError(t *testing.T) {
 }
 
 func TestDomain_DeletingWithCertManager(t *testing.T) {
-	os.Setenv(certManagerEnv, certManagerCertManagerIO)
+	t.Setenv(certManagerEnv, certManagerCertManagerIO)
 
 	reconcileTestItem(
 		context.TODO(), t,
@@ -679,7 +678,7 @@ func TestDomain_DeletingWithCertManager(t *testing.T) {
 		},
 	)
 
-	os.Setenv(certManagerEnv, "")
+	t.Setenv(certManagerEnv, "")
 }
 
 func TestDomain_DuplicateDomains(t *testing.T) {

--- a/internal/controller/reconcile_test.go
+++ b/internal/controller/reconcile_test.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"os"
 	"reflect"
 	"strconv"
 	"strings"
@@ -366,10 +365,6 @@ func getTestController(resources testResources) *Controller {
 }
 
 func TestMain(m *testing.M) {
-	os.Setenv(certManagerEnv, "gardener")
-	os.Setenv(dnsManagerEnv, "gardener")
-	defer os.Setenv(certManagerEnv, "")
-	defer os.Setenv(dnsManagerEnv, "")
 	m.Run()
 }
 

--- a/internal/controller/rollout-manager_test.go
+++ b/internal/controller/rollout-manager_test.go
@@ -7,7 +7,6 @@ package controller
 
 import (
 	"context"
-	"os"
 	"testing"
 	"time"
 
@@ -143,8 +142,6 @@ func TestGetRolloutDelay_DefaultWhenUnset(t *testing.T) {
 }
 
 func TestGetRolloutDelay_DefaultWhenEnvVarNotPresent(t *testing.T) {
-	os.Unsetenv(EnvRolloutDelay)
-	t.Cleanup(func() { os.Unsetenv(EnvRolloutDelay) })
 	if got := getRolloutDelay(); got != defaultRolloutDelay {
 		t.Errorf("expected default %v when env var absent, got %v", defaultRolloutDelay, got)
 	}

--- a/internal/controller/version-monitoring_test.go
+++ b/internal/controller/version-monitoring_test.go
@@ -12,7 +12,6 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -42,16 +41,13 @@ func TestMonitoringEnv(t *testing.T) {
 	for _, tt := range tests {
 		t.Run("test monitoring env", func(t *testing.T) {
 			if tt.add != nil {
-				os.Setenv(EnvPrometheusAddress, *tt.add)
-				defer os.Unsetenv(EnvPrometheusAddress)
+				t.Setenv(EnvPrometheusAddress, *tt.add)
 			}
 			if tt.acqRetryInt != nil {
-				os.Setenv(EnvPrometheusAcquireClientRetryDelay, *tt.acqRetryInt)
-				defer os.Unsetenv(EnvPrometheusAcquireClientRetryDelay)
+				t.Setenv(EnvPrometheusAcquireClientRetryDelay, *tt.acqRetryInt)
 			}
 			if tt.evalInt != nil {
-				os.Setenv(EnvMetricsEvaluationInterval, *tt.evalInt)
-				defer os.Unsetenv(EnvMetricsEvaluationInterval)
+				t.Setenv(EnvMetricsEvaluationInterval, *tt.evalInt)
 			}
 
 			mEnv := parseMonitoringEnv()
@@ -134,8 +130,7 @@ func TestGracefulShutdownMonitoringRoutines(t *testing.T) {
 		s, _ := getPromServer(false, []queryTestCase{})
 		defer s.Close()
 
-		os.Setenv(EnvPrometheusAddress, s.URL)
-		defer os.Unsetenv(EnvPrometheusAddress)
+		t.Setenv(EnvPrometheusAddress, s.URL)
 
 		testCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 		defer cancel()
@@ -149,9 +144,6 @@ func TestGracefulShutdownMonitoringRoutines(t *testing.T) {
 
 	t.Run("without PROMETHEUS_ADDRESS set", func(t *testing.T) {
 		defer deregisterMetrics()
-
-		// Ensure the env var is not set.
-		os.Unsetenv(EnvPrometheusAddress)
 
 		c := setupTestControllerWithInitialResources(t, []string{})
 


### PR DESCRIPTION
Use Setenv from go `testing.T` framework instead of `os` in unit tests.